### PR TITLE
Add vitest infrastructure and 98 tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1480 @@
+{
+  "name": "ilo",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ilo",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.3.0",
+        "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/tests/composition.test.ts
+++ b/tests/composition.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../src/core";
+import { num } from "../src/plugins/num";
+import { str } from "../src/plugins/str";
+import { postgres } from "../src/plugins/postgres";
+import { fiber } from "../src/plugins/fiber";
+import { error } from "../src/plugins/error";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v))
+  );
+}
+
+const app = ilo(num, str, postgres("postgres://localhost/test"), fiber, error);
+
+describe("composition: postgres + fiber", () => {
+  it("$.par wrapping postgres queries nests correctly", () => {
+    const prog = app(($) => {
+      return $.par(
+        $.sql`select count(*) from users`,
+        $.sql`select count(*) from posts`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/par");
+    expect(ast.result.branches[0].kind).toBe("postgres/query");
+    expect(ast.result.branches[1].kind).toBe("postgres/query");
+  });
+
+  it("$.par map form over postgres query results", () => {
+    const prog = app(($) => {
+      const users = $.sql`select * from users`;
+      return $.par(users, { concurrency: 5 }, (user) =>
+        $.sql`select * from posts where user_id = ${user.id}`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/par_map");
+    expect(ast.result.collection.kind).toBe("postgres/query");
+    expect(ast.result.body.kind).toBe("postgres/query");
+  });
+});
+
+describe("composition: postgres + error", () => {
+  it("$.try wrapping postgres query produces correct nesting", () => {
+    const prog = app(($) => {
+      return $.try($.sql`select * from users where id = ${$.input.id}`)
+        .catch((err) => ({ error: err.message }));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.expr.kind).toBe("postgres/query");
+  });
+
+  it("$.guard inside transaction with $.do", () => {
+    const prog = app(($) => {
+      return $.sql.begin((sql) => {
+        const from = sql`select * from accounts where id = ${$.input.fromId}`;
+        return $.do(
+          $.guard($.gt(from[0].balance, $.input.amount), { code: "INSUFFICIENT" }),
+          sql`update accounts set balance = balance - ${$.input.amount} where id = ${$.input.fromId}`,
+          { success: true }
+        );
+      });
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("postgres/begin");
+    const doNode = ast.result.body;
+    expect(doNode.steps[0].kind).toBe("error/guard");
+    expect(doNode.steps[1].kind).toBe("postgres/query");
+  });
+});
+
+describe("composition: postgres + fiber + error (full stack)", () => {
+  it("$.try($.par(...)).catch() — the full monty", () => {
+    const prog = app(($) => {
+      return $.try(
+        $.par(
+          $.sql`select * from service_a`,
+          $.sql`select * from service_b`
+        )
+      ).catch((_err) => []);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.expr.kind).toBe("fiber/par");
+    expect(ast.result.expr.branches[0].kind).toBe("postgres/query");
+  });
+
+  it("guard → par_map → try → retry → catch nests correctly", () => {
+    const prog = app(($) => {
+      const users = $.sql`select * from users where active = true`;
+      return $.do(
+        $.guard($.gt(users.length, 0), { code: 404, message: "no users" }),
+        $.par(users, { concurrency: 5 }, (user) =>
+          $.try(
+            $.retry(
+              $.sql`select * from posts where user_id = ${user.id}`,
+              { attempts: 2, delay: 500 }
+            )
+          ).catch((_err) => [])
+        )
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/do");
+    expect(ast.result.steps[0].kind).toBe("error/guard");
+    expect(ast.result.result.kind).toBe("fiber/par_map");
+    expect(ast.result.result.body.kind).toBe("error/try");
+    expect(ast.result.result.body.expr.kind).toBe("fiber/retry");
+    expect(ast.result.result.body.expr.expr.kind).toBe("postgres/query");
+  });
+
+  it("safeTransfer: try → begin → guard + do → catch", () => {
+    const prog = app(($) => {
+      return $.try(
+        $.sql.begin((sql) => {
+          const from = sql`select * from accounts where id = ${$.input.fromId} for update`;
+          const to = sql`select * from accounts where id = ${$.input.toId} for update`;
+          return $.do(
+            $.guard($.gt(from[0].balance, $.input.amount), { code: "INSUFFICIENT_FUNDS" }),
+            sql`update accounts set balance = balance - ${$.input.amount} where id = ${$.input.fromId}`,
+            sql`update accounts set balance = balance + ${$.input.amount} where id = ${$.input.toId}`,
+            {
+              success: true,
+              fromBalance: $.sub(from[0].balance, $.input.amount),
+              toBalance: $.add(to[0].balance, $.input.amount),
+            }
+          );
+        })
+      ).catch((err) => ({ success: false, error: err }));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.expr.kind).toBe("postgres/begin");
+    expect(ast.result.expr.body.kind).toBe("core/do");
+    expect(ast.result.expr.body.steps[0].kind).toBe("error/guard");
+    expect(ast.result.catch.body.kind).toBe("core/record");
+  });
+});

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../src/core";
+import { num } from "../src/plugins/num";
+import { str } from "../src/plugins/str";
+
+// Helper: strip __id from AST for snapshot-stable assertions
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+describe("core: $.do()", () => {
+  const app = ilo(num, str);
+
+  it("sequences side effects with last arg as return value", () => {
+    const prog = app(($) => {
+      const a = $.add(1, 2);
+      const b = $.add(3, 4);
+      return $.do(a, b);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/do");
+    expect(ast.result.steps).toHaveLength(1);
+    expect(ast.result.steps[0].kind).toBe("num/add");
+    expect(ast.result.result.kind).toBe("num/add");
+  });
+
+  it("works with a single expression (no steps)", () => {
+    const prog = app(($) => {
+      return $.do($.add(1, 2));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/do");
+    expect(ast.result.steps).toHaveLength(0);
+    expect(ast.result.result.kind).toBe("num/add");
+  });
+});
+
+describe("core: $.cond()", () => {
+  const app = ilo(num);
+
+  it("produces a core/cond node with both branches via .t().f()", () => {
+    const prog = app(($) => {
+      return $.cond($.eq($.input.x, 1))
+        .t($.add(1, 2))
+        .f($.add(3, 4));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/cond");
+    expect(ast.result.then.kind).toBe("num/add");
+    expect(ast.result.else.kind).toBe("num/add");
+  });
+
+  it("works with .f().t() order", () => {
+    const prog = app(($) => {
+      return $.cond($.eq($.input.x, 1))
+        .f($.add(3, 4))
+        .t($.add(1, 2));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/cond");
+    expect(ast.result.then.kind).toBe("num/add");
+    expect(ast.result.else.kind).toBe("num/add");
+  });
+
+  it("auto-lifts raw values in branches", () => {
+    const prog = app(($) => {
+      return $.cond($.eq($.input.x, 1)).t("yes").f("no");
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.then.kind).toBe("core/literal");
+    expect(ast.result.then.value).toBe("yes");
+    expect(ast.result.else.kind).toBe("core/literal");
+    expect(ast.result.else.value).toBe("no");
+  });
+});
+
+describe("core: $.eq(), $.and(), $.or(), $.not()", () => {
+  const app = ilo(num);
+
+  it("$.eq produces core/eq", () => {
+    const prog = app(($) => $.eq($.input.x, 1));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/eq");
+    expect(ast.result.right.kind).toBe("core/literal");
+    expect(ast.result.right.value).toBe(1);
+  });
+
+  it("$.and produces core/and", () => {
+    const prog = app(($) => $.and($.eq($.input.x, 1), $.eq($.input.y, 2)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/and");
+  });
+
+  it("$.or produces core/or", () => {
+    const prog = app(($) => $.or($.eq($.input.x, 1), $.eq($.input.y, 2)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/or");
+  });
+
+  it("$.not produces core/not", () => {
+    const prog = app(($) => $.not($.eq($.input.x, 1)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/not");
+    expect(ast.result.operand.kind).toBe("core/eq");
+  });
+});
+
+describe("core: auto-lifting", () => {
+  const app = ilo(num);
+
+  it("lifts raw numbers to core/literal", () => {
+    const prog = app(($) => $.add(1, 2));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.left.kind).toBe("core/literal");
+    expect(ast.result.left.value).toBe(1);
+    expect(ast.result.right.kind).toBe("core/literal");
+    expect(ast.result.right.value).toBe(2);
+  });
+
+  it("lifts raw strings to core/literal", () => {
+    const prog = app(($) => $.eq($.input.name, "alice"));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.right.kind).toBe("core/literal");
+    expect(ast.result.right.value).toBe("alice");
+  });
+
+  it("lifts raw objects to core/record", () => {
+    const prog = app(($) => {
+      return { x: $.add(1, 2), y: "hello" };
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/record");
+    expect(ast.result.fields.x.kind).toBe("num/add");
+    expect(ast.result.fields.y.kind).toBe("core/literal");
+  });
+
+  it("does not re-wrap Expr values", () => {
+    const prog = app(($) => {
+      const a = $.add(1, 2);
+      return $.add(a, 3);
+    });
+    const ast = strip(prog.ast) as any;
+    // left operand should be num/add, not core/literal wrapping it
+    expect(ast.result.left.kind).toBe("num/add");
+  });
+});
+
+describe("core: proxy property access", () => {
+  const app = ilo();
+
+  it("user.firstName produces core/prop_access", () => {
+    const prog = app(($) => $.input.user.firstName);
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/prop_access");
+    expect(ast.result.property).toBe("firstName");
+    expect(ast.result.object.kind).toBe("core/prop_access");
+    expect(ast.result.object.property).toBe("user");
+  });
+
+  it("arr[0] produces core/prop_access with '0'", () => {
+    const prog = app(($) => $.input.items[0]);
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/prop_access");
+    expect(ast.result.property).toBe("0");
+  });
+});
+
+describe("core: array methods produce core/lambda", () => {
+  const app = ilo(num);
+
+  it(".map() produces core/method_call with core/lambda", () => {
+    const prog = app(($) => {
+      return $.input.items.map((item: any) => $.add(item.price, 1));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/method_call");
+    expect(ast.result.method).toBe("map");
+    expect(ast.result.args[0].kind).toBe("core/lambda");
+    expect(ast.result.args[0].body.kind).toBe("num/add");
+  });
+
+  it(".filter() produces core/method_call with core/lambda", () => {
+    const prog = app(($) => {
+      return $.input.items.filter((item: any) => $.eq(item.active, true));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/method_call");
+    expect(ast.result.method).toBe("filter");
+    expect(ast.result.args[0].kind).toBe("core/lambda");
+  });
+
+  it(".reduce() produces core/lambda with accumulator and item params", () => {
+    const prog = app(($) => {
+      return $.input.items.reduce(
+        (sum: any, item: any) => $.add(sum, item.price),
+        0
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/method_call");
+    expect(ast.result.method).toBe("reduce");
+    expect(ast.result.args[0].kind).toBe("core/lambda");
+    expect(ast.result.args[0].params).toHaveLength(2);
+    expect(ast.result.args[0].params[0].name).toBe("accumulator");
+    expect(ast.result.args[0].params[1].name).toBe("item");
+  });
+});
+
+describe("core: reachability analysis", () => {
+  const app = ilo(num, str);
+
+  it("rejects orphaned expressions", () => {
+    expect(() => {
+      app(($) => {
+        $.add(1, 2); // created but not returned
+        return $.add(3, 4);
+      });
+    }).toThrow(/unreachable node/i);
+  });
+
+  it("rejects multiple orphans", () => {
+    expect(() => {
+      app(($) => {
+        $.add(1, 2);
+        $.add(3, 4);
+        return $.add(5, 6);
+      });
+    }).toThrow(/2 unreachable node/);
+  });
+
+  it("does not reject pure computations with all nodes connected", () => {
+    expect(() => {
+      app(($) => {
+        const a = $.add(1, 2);
+        const b = $.add(a, 3);
+        return b;
+      });
+    }).not.toThrow();
+  });
+
+  it("does not reject nodes inside $.do()", () => {
+    expect(() => {
+      app(($) => {
+        const sideEffect = $.add(1, 2);
+        const result = $.add(3, 4);
+        return $.do(sideEffect, result);
+      });
+    }).not.toThrow();
+  });
+
+  it("does not reject nodes inside .map() callbacks", () => {
+    expect(() => {
+      app(($) => {
+        return $.input.items.map((item: any) => ({
+          name: item.name,
+          score: $.add(item.x, 1),
+        }));
+      });
+    }).not.toThrow();
+  });
+
+  it("does not false-positive on $.input or $.noop", () => {
+    expect(() => {
+      app(($) => {
+        $.input.unused; // accessing input doesn't create orphans
+        return $.noop;
+      });
+    }).not.toThrow();
+  });
+});
+
+describe("core: content hashing", () => {
+  const app = ilo(num);
+
+  it("identical programs produce identical hashes", () => {
+    const prog1 = app(($) => $.add($.input.x, 1));
+    const prog2 = app(($) => $.add($.input.x, 1));
+    expect(prog1.hash).toBe(prog2.hash);
+  });
+
+  it("different programs produce different hashes", () => {
+    const prog1 = app(($) => $.add($.input.x, 1));
+    const prog2 = app(($) => $.add($.input.x, 2));
+    expect(prog1.hash).not.toBe(prog2.hash);
+  });
+});
+
+describe("core: program metadata", () => {
+  it("lists plugin names", () => {
+    const app = ilo(num, str);
+    const prog = app(($) => $.add(1, 2));
+    expect(prog.plugins).toEqual(["num", "str"]);
+  });
+
+  it("works with no plugins", () => {
+    const app = ilo();
+    const prog = app(($) => $.input.x);
+    expect(prog.plugins).toEqual([]);
+  });
+});

--- a/tests/plugins/error.test.ts
+++ b/tests/plugins/error.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../../src/core";
+import { num } from "../../src/plugins/num";
+import { error } from "../../src/plugins/error";
+import { postgres } from "../../src/plugins/postgres";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v))
+  );
+}
+
+const app = ilo(num, postgres("postgres://localhost/test"), error);
+
+describe("error: $.try().catch()", () => {
+  it("produces error/try with catch branch", () => {
+    const prog = app(($) => {
+      return $.try($.sql`select * from users where id = ${$.input.id}`)
+        .catch((err) => ({ error: err.message, data: null }));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.expr.kind).toBe("postgres/query");
+    expect(ast.result.catch.param.kind).toBe("core/lambda_param");
+    expect(ast.result.catch.body.kind).toBe("core/record");
+  });
+});
+
+describe("error: $.try().match()", () => {
+  it("produces error/try with match branches", () => {
+    const prog = app(($) => {
+      return $.try($.sql`select * from users where id = ${$.input.id}`)
+        .match({
+          not_found: (_err) => "default_user",
+          timeout: (_err) => "cached_user",
+          _: (err) => $.fail(err),
+        });
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.match).toBeDefined();
+    expect(ast.result.match.branches.not_found.kind).toBe("core/literal");
+    expect(ast.result.match.branches.timeout.kind).toBe("core/literal");
+    expect(ast.result.match.branches._.kind).toBe("error/fail");
+  });
+});
+
+describe("error: $.try().finally()", () => {
+  it("produces error/try with finally node", () => {
+    const prog = app(($) => {
+      return $.try($.sql`delete from users where id = ${$.input.id}`)
+        .finally($.sql`insert into audit_log (action) values ('delete')`)
+        .catch((err) => ({ error: err.message }));
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.finally).not.toBeNull();
+    expect(ast.result.finally.kind).toBe("postgres/query");
+  });
+});
+
+describe("error: $.fail()", () => {
+  it("produces error/fail node", () => {
+    const prog = app(($) => {
+      return $.cond($.eq($.input.x, null))
+        .t($.fail({ code: 404, message: "not found" }))
+        .f($.input.x);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.then.kind).toBe("error/fail");
+    expect(ast.result.then.error.kind).toBe("core/record");
+  });
+});
+
+describe("error: $.orElse()", () => {
+  it("produces error/try with catch that returns fallback", () => {
+    const prog = app(($) => {
+      return $.orElse(
+        $.sql`select * from users where id = ${$.input.id}`,
+        [{ name: "anonymous" }]
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/try");
+    expect(ast.result.catch.param.name).toBe("_err");
+  });
+});
+
+describe("error: $.attempt()", () => {
+  it("produces error/attempt node", () => {
+    const prog = app(($) => {
+      const result = $.attempt($.sql`select * from users where id = ${$.input.id}`);
+      return $.cond($.eq(result.err, null))
+        .t({ found: true, user: result.ok })
+        .f({ found: false, error: result.err });
+    });
+    const ast = strip(prog.ast) as any;
+    // result.ok and result.err are prop_access on the attempt node
+    expect(ast.result.then.kind).toBe("core/record");
+  });
+});
+
+describe("error: $.guard()", () => {
+  it("produces error/guard node", () => {
+    const prog = app(($) => {
+      return $.do(
+        $.guard($.gt($.input.balance, $.input.amount), {
+          code: 400,
+          message: "insufficient funds",
+        }),
+        $.sql`update accounts set balance = balance - ${$.input.amount}`,
+        { success: true }
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    const guardNode = ast.result.steps[0];
+    expect(guardNode.kind).toBe("error/guard");
+    expect(guardNode.condition.kind).toBe("num/gt");
+    expect(guardNode.error.kind).toBe("core/record");
+  });
+});
+
+describe("error: $.settle()", () => {
+  it("produces error/settle with multiple expressions", () => {
+    const prog = app(($) => {
+      return $.settle(
+        $.sql`select 1 from users limit 1`,
+        $.sql`select 1 from posts limit 1`,
+        $.sql`select 1 from comments limit 1`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("error/settle");
+    expect(ast.result.exprs).toHaveLength(3);
+    expect(ast.result.exprs[0].kind).toBe("postgres/query");
+  });
+});

--- a/tests/plugins/fiber.test.ts
+++ b/tests/plugins/fiber.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../../src/core";
+import { num } from "../../src/plugins/num";
+import { fiber } from "../../src/plugins/fiber";
+import { postgres } from "../../src/plugins/postgres";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v))
+  );
+}
+
+const app = ilo(num, postgres("postgres://localhost/test"), fiber);
+
+describe("fiber: $.par() tuple form", () => {
+  it("produces fiber/par node with branches", () => {
+    const prog = app(($) => {
+      return $.par(
+        $.sql`select count(*) from users`,
+        $.sql`select count(*) from posts`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/par");
+    expect(ast.result.branches).toHaveLength(2);
+    expect(ast.result.branches[0].kind).toBe("postgres/query");
+    expect(ast.result.branches[1].kind).toBe("postgres/query");
+  });
+
+  it("works with 3+ branches", () => {
+    const prog = app(($) => {
+      return $.par(
+        $.sql`select 1`,
+        $.sql`select 2`,
+        $.sql`select 3`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.branches).toHaveLength(3);
+  });
+});
+
+describe("fiber: $.par() map form", () => {
+  it("produces fiber/par_map with concurrency and lambda", () => {
+    const prog = app(($) => {
+      const users = $.sql`select * from users where active = true`;
+      return $.par(users, { concurrency: 5 }, (user) =>
+        $.sql`select * from posts where user_id = ${user.id}`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/par_map");
+    expect(ast.result.concurrency).toBe(5);
+    expect(ast.result.collection.kind).toBe("postgres/query");
+    expect(ast.result.param.kind).toBe("core/lambda_param");
+    expect(ast.result.body.kind).toBe("postgres/query");
+  });
+});
+
+describe("fiber: $.seq()", () => {
+  it("produces fiber/seq with steps and result", () => {
+    const prog = app(($) => {
+      return $.seq(
+        $.sql`insert into log (msg) values ('start')`,
+        $.sql`insert into log (msg) values ('end')`,
+        $.sql`select * from log`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/seq");
+    expect(ast.result.steps).toHaveLength(2);
+    expect(ast.result.result.kind).toBe("postgres/query");
+  });
+});
+
+describe("fiber: $.race()", () => {
+  it("produces fiber/race with branches", () => {
+    const prog = app(($) => {
+      return $.race(
+        $.sql`select * from users_primary where id = ${$.input.id}`,
+        $.sql`select * from users_replica where id = ${$.input.id}`
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/race");
+    expect(ast.result.branches).toHaveLength(2);
+  });
+});
+
+describe("fiber: $.timeout()", () => {
+  it("produces fiber/timeout with ms and fallback", () => {
+    const prog = app(($) => {
+      return $.timeout(
+        $.sql`select * from slow_view`,
+        5000,
+        { error: "timeout" }
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/timeout");
+    expect(ast.result.ms.kind).toBe("core/literal");
+    expect(ast.result.ms.value).toBe(5000);
+    expect(ast.result.fallback.kind).toBe("core/record");
+  });
+
+  it("accepts Expr<number> for ms", () => {
+    const prog = app(($) => {
+      return $.timeout($.sql`select 1`, $.input.timeoutMs, "fallback");
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.ms.kind).toBe("core/prop_access");
+  });
+});
+
+describe("fiber: $.retry()", () => {
+  it("produces fiber/retry with attempts and delay", () => {
+    const prog = app(($) => {
+      return $.retry(
+        $.sql`select * from flaky_service`,
+        { attempts: 3, delay: 1000 }
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/retry");
+    expect(ast.result.attempts).toBe(3);
+    expect(ast.result.delay).toBe(1000);
+  });
+
+  it("defaults delay to 0", () => {
+    const prog = app(($) => {
+      return $.retry($.sql`select 1`, { attempts: 2 });
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.delay).toBe(0);
+  });
+});
+
+describe("fiber: nested composition", () => {
+  it("par_map → retry → par nests correctly", () => {
+    const prog = app(($) => {
+      const users = $.sql`select * from users where active = true`;
+      return $.par(users, { concurrency: 5 }, (user) =>
+        $.retry(
+          $.par(
+            $.sql`select * from posts where user_id = ${user.id}`,
+            $.sql`select * from comments where user_id = ${user.id}`
+          ),
+          { attempts: 2, delay: 500 }
+        )
+      );
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("fiber/par_map");
+    expect(ast.result.body.kind).toBe("fiber/retry");
+    expect(ast.result.body.expr.kind).toBe("fiber/par");
+    expect(ast.result.body.expr.branches).toHaveLength(2);
+  });
+});

--- a/tests/plugins/num.test.ts
+++ b/tests/plugins/num.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../../src/core";
+import { num } from "../../src/plugins/num";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+const app = ilo(num);
+
+describe("num: binary operations", () => {
+  it.each([
+    ["add", "num/add"],
+    ["sub", "num/sub"],
+    ["mul", "num/mul"],
+    ["div", "num/div"],
+    ["mod", "num/mod"],
+  ] as const)("$.%s produces %s node", (method, kind) => {
+    const prog = app(($) => ($[method] as any)($.input.a, $.input.b));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe(kind);
+    expect(ast.result.left.kind).toBe("core/prop_access");
+    expect(ast.result.right.kind).toBe("core/prop_access");
+  });
+});
+
+describe("num: comparison operations", () => {
+  it.each([
+    ["gt", "num/gt"],
+    ["gte", "num/gte"],
+    ["lt", "num/lt"],
+    ["lte", "num/lte"],
+  ] as const)("$.%s produces %s node", (method, kind) => {
+    const prog = app(($) => ($[method] as any)($.input.a, 10));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe(kind);
+    expect(ast.result.right.kind).toBe("core/literal");
+    expect(ast.result.right.value).toBe(10);
+  });
+});
+
+describe("num: unary operations", () => {
+  it.each([
+    ["neg", "num/neg"],
+    ["abs", "num/abs"],
+    ["floor", "num/floor"],
+    ["ceil", "num/ceil"],
+    ["round", "num/round"],
+  ] as const)("$.%s produces %s node", (method, kind) => {
+    const prog = app(($) => ($[method] as any)($.input.x));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe(kind);
+    expect(ast.result.operand.kind).toBe("core/prop_access");
+  });
+});
+
+describe("num: variadic operations", () => {
+  it("$.min produces num/min with values array", () => {
+    const prog = app(($) => $.min($.input.a, $.input.b, 0));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("num/min");
+    expect(ast.result.values).toHaveLength(3);
+    expect(ast.result.values[2].kind).toBe("core/literal");
+  });
+
+  it("$.max produces num/max with values array", () => {
+    const prog = app(($) => $.max($.input.a, 100));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("num/max");
+    expect(ast.result.values).toHaveLength(2);
+  });
+});
+
+describe("num: auto-lifting", () => {
+  it("lifts raw numbers on both sides", () => {
+    const prog = app(($) => $.add(1, 2));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.left.kind).toBe("core/literal");
+    expect(ast.result.left.value).toBe(1);
+    expect(ast.result.right.kind).toBe("core/literal");
+    expect(ast.result.right.value).toBe(2);
+  });
+
+  it("passes through Expr values without wrapping", () => {
+    const prog = app(($) => $.add($.input.x, 1));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.left.kind).toBe("core/prop_access");
+    expect(ast.result.right.kind).toBe("core/literal");
+  });
+});

--- a/tests/plugins/postgres.test.ts
+++ b/tests/plugins/postgres.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../../src/core";
+import { num } from "../../src/plugins/num";
+import { str } from "../../src/plugins/str";
+import { postgres } from "../../src/plugins/postgres";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v))
+  );
+}
+
+const app = ilo(num, str, postgres("postgres://localhost/test"));
+
+// ============================================================
+// Parity tests: encoding the Honest Assessment Matrix
+// ============================================================
+
+describe("postgres: tagged template queries", () => {
+  it("basic query produces postgres/query node", () => {
+    const prog = app(($) => {
+      return $.sql`select * from users where age > ${30}`;
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("postgres/query");
+    expect(ast.result.strings).toEqual(["select * from users where age > ", ""]);
+    expect(ast.result.params).toHaveLength(1);
+    expect(ast.result.params[0].kind).toBe("core/literal");
+    expect(ast.result.params[0].value).toBe(30);
+  });
+
+  it("parameterized query with Expr values captures dependency", () => {
+    const prog = app(($) => {
+      const user = $.sql`select * from users where id = ${$.input.id}`;
+      const posts = $.sql`select * from posts where user_id = ${user[0].id}`;
+      return { user: user[0], posts };
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/record");
+    expect(ast.result.fields.posts.kind).toBe("postgres/query");
+    // The param should reference through prop_access chain, not a literal
+    const postParam = ast.result.fields.posts.params[0];
+    expect(postParam.kind).toBe("core/prop_access");
+  });
+
+  it("query with no params produces empty params array", () => {
+    const prog = app(($) => $.sql`select 1`);
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.params).toEqual([]);
+  });
+});
+
+describe("postgres: dynamic identifiers ($.sql.id)", () => {
+  it("produces postgres/identifier node", () => {
+    const prog = app(($) => {
+      return $.sql`select ${$.sql.id("name")} from users`;
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("postgres/query");
+    expect(ast.result.params[0].kind).toBe("postgres/identifier");
+  });
+
+  it("accepts Expr<string> argument", () => {
+    const prog = app(($) => {
+      return $.sql`select ${$.sql.id($.input.column)} from users`;
+    });
+    const ast = strip(prog.ast) as any;
+    const idNode = ast.result.params[0];
+    expect(idNode.kind).toBe("postgres/identifier");
+    expect(idNode.name.kind).toBe("core/prop_access");
+  });
+});
+
+describe("postgres: insert helper ($.sql.insert)", () => {
+  it("produces postgres/insert_helper node", () => {
+    const prog = app(($) => {
+      return $.sql`insert into users ${$.sql.insert($.input.user, ["name", "age"])} returning *`;
+    });
+    const ast = strip(prog.ast) as any;
+    const insertNode = ast.result.params[0];
+    expect(insertNode.kind).toBe("postgres/insert_helper");
+    expect(insertNode.columns).toEqual(["name", "age"]);
+  });
+});
+
+describe("postgres: set helper ($.sql.set)", () => {
+  it("produces postgres/set_helper node", () => {
+    const prog = app(($) => {
+      return $.sql`update users set ${$.sql.set($.input.data, ["name", "age"])} where id = ${$.input.id}`;
+    });
+    const ast = strip(prog.ast) as any;
+    // First param is the set helper, second is the id
+    const setNode = ast.result.params[0];
+    expect(setNode.kind).toBe("postgres/set_helper");
+    expect(setNode.columns).toEqual(["name", "age"]);
+  });
+});
+
+describe("postgres: transactions", () => {
+  it("pipeline mode (array return) produces postgres/begin with mode=pipeline", () => {
+    const prog = app(($) => {
+      return $.sql.begin((sql) => [
+        sql`update users set active = false where id = ${$.input.id}`,
+        sql`insert into audit_log (action) values ('deactivate')`,
+      ]);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("postgres/begin");
+    expect(ast.result.mode).toBe("pipeline");
+    expect(ast.result.queries).toHaveLength(2);
+    expect(ast.result.queries[0].kind).toBe("postgres/query");
+    expect(ast.result.queries[1].kind).toBe("postgres/query");
+  });
+
+  it("callback mode (Expr return) produces postgres/begin with mode=callback", () => {
+    const prog = app(($) => {
+      return $.sql.begin((sql) => {
+        const user = sql`insert into users (name) values ('test') returning *`;
+        const account = sql`insert into accounts (user_id) values (${user[0].id}) returning *`;
+        return $.do(user, account, { user: user[0], account: account[0] });
+      });
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("postgres/begin");
+    expect(ast.result.mode).toBe("callback");
+    expect(ast.result.body.kind).toBe("core/do");
+  });
+
+  it("transaction sql instance has savepoint", () => {
+    const prog = app(($) => {
+      return $.sql.begin((sql) => {
+        const user = sql`select * from users where id = ${$.input.id}`;
+        const sp = (sql as any).savepoint((sql2: any) => [
+          sql2`update users set name = 'test' where id = ${user[0].id}`,
+        ]);
+        return $.do(sp, user[0]);
+      });
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("postgres/begin");
+    const doNode = ast.result.body;
+    expect(doNode.kind).toBe("core/do");
+    expect(doNode.steps[0].kind).toBe("postgres/savepoint");
+  });
+});
+
+describe("postgres: integration with $.do()", () => {
+  it("side-effecting queries wrapped in $.do() are reachable", () => {
+    expect(() => {
+      app(($) => {
+        const user = $.sql`select * from users where id = ${$.input.id}`;
+        return $.do(
+          $.sql`update users set last_seen = now() where id = ${$.input.id}`,
+          user[0]
+        );
+      });
+    }).not.toThrow();
+  });
+
+  it("orphaned queries are rejected", () => {
+    expect(() => {
+      app(($) => {
+        const user = $.sql`select * from users where id = ${$.input.id}`;
+        $.sql`update users set last_seen = now() where id = ${$.input.id}`; // orphan!
+        return user[0];
+      });
+    }).toThrow(/unreachable node/i);
+  });
+});

--- a/tests/plugins/str.test.ts
+++ b/tests/plugins/str.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { ilo } from "../../src/core";
+import { str } from "../../src/plugins/str";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+const app = ilo(str);
+
+describe("str: tagged template", () => {
+  it("produces str/template node", () => {
+    const prog = app(($) => $.str`hello ${$.input.name}`);
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/template");
+    expect(ast.result.strings).toEqual(["hello ", ""]);
+    expect(ast.result.exprs).toHaveLength(1);
+  });
+
+  it("handles template with no interpolations", () => {
+    const prog = app(($) => $.str`hello world`);
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/template");
+    expect(ast.result.strings).toEqual(["hello world"]);
+    expect(ast.result.exprs).toEqual([]);
+  });
+});
+
+describe("str: concat", () => {
+  it("produces str/concat with parts", () => {
+    const prog = app(($) => $.concat($.input.first, " ", $.input.last));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/concat");
+    expect(ast.result.parts).toHaveLength(3);
+    expect(ast.result.parts[1].kind).toBe("core/literal");
+    expect(ast.result.parts[1].value).toBe(" ");
+  });
+});
+
+describe("str: unary string operations", () => {
+  it.each([
+    ["upper", "str/upper"],
+    ["lower", "str/lower"],
+    ["trim", "str/trim"],
+  ] as const)("$.%s produces %s node", (method, kind) => {
+    const prog = app(($) => ($[method] as any)($.input.s));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe(kind);
+    expect(ast.result.operand.kind).toBe("core/prop_access");
+  });
+});
+
+describe("str: slice", () => {
+  it("produces str/slice with start", () => {
+    const prog = app(($) => $.slice($.input.s, 0, 5));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/slice");
+    expect(ast.result.start.value).toBe(0);
+    expect(ast.result.end.value).toBe(5);
+  });
+
+  it("omits end when not provided", () => {
+    const prog = app(($) => $.slice($.input.s, 3));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/slice");
+    expect(ast.result.end).toBeUndefined();
+  });
+});
+
+describe("str: boolean operations", () => {
+  it.each([
+    ["includes", "str/includes"],
+    ["startsWith", "str/startsWith"],
+    ["endsWith", "str/endsWith"],
+  ] as const)("$.%s produces %s node", (method, kind) => {
+    const prog = app(($) => ($[method] as any)($.input.s, "test"));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe(kind);
+  });
+});
+
+describe("str: split, join, replace, len", () => {
+  it("$.split produces str/split", () => {
+    const prog = app(($) => $.split($.input.s, ","));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/split");
+  });
+
+  it("$.join produces str/join", () => {
+    const prog = app(($) => $.join($.input.arr, ", "));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/join");
+  });
+
+  it("$.replace produces str/replace", () => {
+    const prog = app(($) => $.replace($.input.s, "old", "new"));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/replace");
+  });
+
+  it("$.len produces str/len", () => {
+    const prog = app(($) => $.len($.input.s));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("str/len");
+  });
+});


### PR DESCRIPTION
Closes #3

## What this does

Adds vitest as the test framework and 98 tests covering the entire DSL surface. Tests are organized per VISION.md §6: parity tests for real-world plugins (postgres), structural tests for abstract plugins (fiber, error), and composition tests for cross-plugin interactions.

**Test breakdown:**
- `tests/core.test.ts` (28) — $.do, $.cond, $.eq/and/or/not, auto-lifting, proxy property access, array method lambdas (.map/.filter/.reduce), reachability analysis (orphan detection, no false positives), content hashing, program metadata
- `tests/plugins/num.test.ts` (18) — all binary, comparison, unary, variadic ops via `it.each`
- `tests/plugins/str.test.ts` (15) — tagged template, concat, unary ops, slice, boolean ops, split/join/replace/len
- `tests/plugins/postgres.test.ts` (12) — parity tests encoding the Honest Assessment Matrix: queries, identifiers, insert/set helpers, pipeline + callback transactions, savepoints, $.do integration, orphan detection
- `tests/plugins/fiber.test.ts` (10) — par (tuple + map), seq, race, timeout, retry, nested composition
- `tests/plugins/error.test.ts` (8) — try/catch, try/match, try/finally, fail, orElse, attempt, guard, settle
- `tests/composition.test.ts` (7) — postgres+fiber, postgres+error, full stack (guard → par_map → try → retry → catch), safeTransfer

## Design alignment

- **§6 Testing Philosophy**: Parity tests for postgres (mirrors postgres.js API), structural tests for fiber/error. "Tests do not execute programs. Tests verify that the AST builder produces the right tree."
- **§7 File Organization**: Tests in `tests/` with `tests/plugins/` subdirectory matching `src/plugins/`.

## Validation performed

- `npx vitest run` — 98/98 passing, 323ms total
- `npx tsc` — clean build, zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)