### PR TITLE
Add CI pipeline: Biome + GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Format & Lint
+        run: npm run check
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ PR body must include:
 - `Closes #<N>`
 - **What this does**: 2-3 sentences
 - **Design alignment**: For each VISION.md principle referenced in the issue, confirm how the implementation matches. Any deviation must reference an approved `spec-change` issue.
-- **Validation performed**: What you tested (`npm run build`, `npm run demo`, manual AST inspection). Evidence, not claims.
+- **Validation performed**: What you tested (`npm run build`, `npm test`, `npm run check`). Evidence, not claims.
 
 ## Required skills for all workflow operations
 
@@ -72,7 +72,7 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 - **NEVER merge PRs without explicit user authorization.** Always wait for the user to say "merge it" (or equivalent). Creating a PR is fine; merging is not. Bot reviewers (CodeRabbit, Copilot) need time to review, and the user needs to see their feedback before deciding to merge. No exceptions.
 - **SCAFFOLD code**: If you encounter code marked `SCAFFOLD`, don't modify/extend/build on it beyond its stated purpose. When you create scaffold code, add a `SCAFFOLD(phase, #issue)` comment and create a `scaffold-cleanup` issue.
 - **Spec seems wrong?** STOP. Open a GitHub Issue labeled `spec-change` with: the problem (with evidence), affected VISION.md sections, proposed change, downstream impact. Don't build on a wrong assumption.
-- **Type-check**: Validate with `npm run build`. AST output must be inspectable and deterministic.
+- **Type-check and lint**: Validate with `npm run build && npm run check && npm test`. AST output must be inspectable and deterministic.
 - **Wait for CI before merging.** After creating a PR, use `gh pr checks <N> --watch` or `sleep 60 && gh pr checks <N>` to confirm all checks pass before requesting merge authorization. Never merge a red PR.
 - **Every plugin must follow the contract in `src/plugin-authoring-guide.ts`.** Three fields: `name`, `nodeKinds`, `build(ctx)`. No exceptions.
 - **AST nodes must be namespaced to their plugin** (`plugin/kind`, not bare `kind`). The `nodeKinds` array in the plugin definition must list every kind the plugin emits.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noThenProperty": "off"
+      },
+      "complexity": {
+        "noBannedTypes": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "performance": {
+        "noAccumulatingSpread": "off"
+      }
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "files": {
+    "includes": ["src/**", "tests/**"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,172 @@
       "name": "ilo",
       "version": "0.0.1",
       "devDependencies": {
+        "@biomejs/biome": "^2.3.14",
         "typescript": "^5.3.0",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.14.tgz",
+      "integrity": "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.14",
+        "@biomejs/cli-darwin-x64": "2.3.14",
+        "@biomejs/cli-linux-arm64": "2.3.14",
+        "@biomejs/cli-linux-arm64-musl": "2.3.14",
+        "@biomejs/cli-linux-x64": "2.3.14",
+        "@biomejs/cli-linux-x64-musl": "2.3.14",
+        "@biomejs/cli-win32-arm64": "2.3.14",
+        "@biomejs/cli-win32-x64": "2.3.14"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.14.tgz",
+      "integrity": "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.14.tgz",
+      "integrity": "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.14.tgz",
+      "integrity": "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.14.tgz",
+      "integrity": "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.14.tgz",
+      "integrity": "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.14.tgz",
+      "integrity": "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.14.tgz",
+      "integrity": "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.14.tgz",
+      "integrity": "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "check": "biome check .",
+    "format": "biome check --write .",
     "test": "vitest run"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.14",
     "typescript": "^5.3.0",
     "vitest": "^4.0.18"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,16 @@
 // Public API
-export { ilo } from "./core";
-export type { Expr, ASTNode, Program, PluginDefinition, PluginContext, Plugin } from "./core";
 
+export type { ASTNode, Expr, Plugin, PluginContext, PluginDefinition, Program } from "./core";
+export { ilo } from "./core";
+export type { ErrorMethods } from "./plugins/error";
+export { error } from "./plugins/error";
+export type { FiberMethods } from "./plugins/fiber";
+export { fiber } from "./plugins/fiber";
+export type { NumMethods } from "./plugins/num";
 // Structural plugins
 export { num } from "./plugins/num";
-export type { NumMethods } from "./plugins/num";
-export { str } from "./plugins/str";
-export type { StrMethods } from "./plugins/str";
-
+export type { PostgresConfig, PostgresMethods } from "./plugins/postgres";
 // Real-world plugins
 export { postgres } from "./plugins/postgres";
-export type { PostgresMethods, PostgresConfig } from "./plugins/postgres";
-export { fiber } from "./plugins/fiber";
-export type { FiberMethods } from "./plugins/fiber";
-export { error } from "./plugins/error";
-export type { ErrorMethods } from "./plugins/error";
+export type { StrMethods } from "./plugins/str";
+export { str } from "./plugins/str";

--- a/src/plugin-authoring-guide.ts
+++ b/src/plugin-authoring-guide.ts
@@ -8,7 +8,7 @@
 //
 // ============================================================
 
-import type { PluginDefinition, PluginContext, Expr } from "./core";
+import type { Expr, PluginContext, PluginDefinition } from "./core";
 
 // ---- Step 1: Define your type interface -------------------
 //
@@ -17,7 +17,11 @@ import type { PluginDefinition, PluginContext, Expr } from "./core";
 
 export interface StripeMethods {
   stripe: {
-    charge(amount: Expr<number> | number, currency: Expr<string> | string, customerId: Expr<string> | string): Expr<{ id: string; status: string }>;
+    charge(
+      amount: Expr<number> | number,
+      currency: Expr<string> | string,
+      customerId: Expr<string> | string,
+    ): Expr<{ id: string; status: string }>;
     refund(chargeId: Expr<string> | string): Expr<{ id: string; status: string }>;
     getCustomer(id: Expr<string> | string): Expr<Record<string, unknown>>;
   };
@@ -37,9 +41,7 @@ export interface StripeMethods {
 //   ctx.emit(node)     — add a statement-level node
 //   ctx.statements     — the current statement list
 
-export function stripe(config: {
-  publishableKey?: string;
-}): PluginDefinition<StripeMethods> {
+export function stripe(config: { publishableKey?: string }): PluginDefinition<StripeMethods> {
   // Config is captured in the closure — it'll be baked
   // into the AST nodes so the interpreter knows how
   // to execute them.
@@ -91,7 +93,7 @@ export function stripe(config: {
 
 import type { InterpreterFragment } from "./core";
 
-export function stripeInterpreter(secretKey: string): InterpreterFragment {
+export function stripeInterpreter(_secretKey: string): InterpreterFragment {
   return {
     pluginName: "stripe",
     canHandle: (node) => node.kind.startsWith("stripe/"),

--- a/src/plugins/fiber.ts
+++ b/src/plugins/fiber.ts
@@ -28,7 +28,7 @@
 //
 // ============================================================
 
-import type { PluginDefinition, PluginContext, Expr, ASTNode } from "../core";
+import type { ASTNode, Expr, PluginContext, PluginDefinition } from "../core";
 
 // ---- What the plugin adds to $ ----------------------------
 
@@ -113,7 +113,7 @@ interface ParFn {
   <T, R>(
     collection: Expr<T[]>,
     opts: { concurrency: number },
-    fn: (item: Expr<T>) => Expr<R>
+    fn: (item: Expr<T>) => Expr<R>,
   ): Expr<R[]>;
 }
 
@@ -150,9 +150,7 @@ export const fiber: PluginDefinition<FiberMethods> = {
         };
         const paramProxy = ctx.expr(paramNode);
         const bodyResult = fn(paramProxy);
-        const bodyNode = ctx.isExpr(bodyResult)
-          ? bodyResult.__node
-          : ctx.lift(bodyResult).__node;
+        const bodyNode = ctx.isExpr(bodyResult) ? bodyResult.__node : ctx.lift(bodyResult).__node;
 
         return ctx.expr({
           kind: "fiber/par_map",
@@ -166,9 +164,7 @@ export const fiber: PluginDefinition<FiberMethods> = {
       // Tuple form: $.par(a, b, c)
       return ctx.expr({
         kind: "fiber/par",
-        branches: args.map((a: any) =>
-          ctx.isExpr(a) ? a.__node : ctx.lift(a).__node
-        ),
+        branches: args.map((a: any) => (ctx.isExpr(a) ? a.__node : ctx.lift(a).__node)),
       });
     }) as ParFn;
 
@@ -176,9 +172,7 @@ export const fiber: PluginDefinition<FiberMethods> = {
       par: parFn,
 
       seq(...exprs: (Expr<any> | any)[]) {
-        const nodes = exprs.map((e) =>
-          ctx.isExpr(e) ? e.__node : ctx.lift(e).__node
-        );
+        const nodes = exprs.map((e) => (ctx.isExpr(e) ? e.__node : ctx.lift(e).__node));
         return ctx.expr({
           kind: "fiber/seq",
           steps: nodes.slice(0, -1),
@@ -198,9 +192,7 @@ export const fiber: PluginDefinition<FiberMethods> = {
           kind: "fiber/timeout",
           expr: expr.__node,
           ms: ctx.isExpr(ms) ? (ms as Expr<number>).__node : { kind: "core/literal", value: ms },
-          fallback: ctx.isExpr(fallback)
-            ? fallback.__node
-            : ctx.lift(fallback).__node,
+          fallback: ctx.isExpr(fallback) ? fallback.__node : ctx.lift(fallback).__node,
         });
       },
 

--- a/src/plugins/num.ts
+++ b/src/plugins/num.ts
@@ -1,4 +1,4 @@
-import type { PluginDefinition, PluginContext, Expr } from "../core";
+import type { Expr, PluginContext, PluginDefinition } from "../core";
 
 export interface NumMethods {
   add(a: Expr<number> | number, b: Expr<number> | number): Expr<number>;
@@ -22,10 +22,22 @@ export interface NumMethods {
 export const num: PluginDefinition<NumMethods> = {
   name: "num",
   nodeKinds: [
-    "num/add", "num/sub", "num/mul", "num/div", "num/mod",
-    "num/gt", "num/gte", "num/lt", "num/lte",
-    "num/neg", "num/abs", "num/floor", "num/ceil", "num/round",
-    "num/min", "num/max",
+    "num/add",
+    "num/sub",
+    "num/mul",
+    "num/div",
+    "num/mod",
+    "num/gt",
+    "num/gte",
+    "num/lt",
+    "num/lte",
+    "num/neg",
+    "num/abs",
+    "num/floor",
+    "num/ceil",
+    "num/round",
+    "num/min",
+    "num/max",
   ],
   build(ctx: PluginContext): NumMethods {
     const binop = (kind: string) => (a: Expr<number> | number, b: Expr<number> | number) =>

--- a/src/plugins/str.ts
+++ b/src/plugins/str.ts
@@ -1,4 +1,4 @@
-import type { PluginDefinition, PluginContext, Expr } from "../core";
+import type { Expr, PluginContext, PluginDefinition } from "../core";
 
 export interface StrMethods {
   /** Tagged template literal: $.str`hello ${name}` */
@@ -7,22 +7,40 @@ export interface StrMethods {
   upper(s: Expr<string> | string): Expr<string>;
   lower(s: Expr<string> | string): Expr<string>;
   trim(s: Expr<string> | string): Expr<string>;
-  slice(s: Expr<string> | string, start: Expr<number> | number, end?: Expr<number> | number): Expr<string>;
+  slice(
+    s: Expr<string> | string,
+    start: Expr<number> | number,
+    end?: Expr<number> | number,
+  ): Expr<string>;
   includes(haystack: Expr<string> | string, needle: Expr<string> | string): Expr<boolean>;
   startsWith(s: Expr<string> | string, prefix: Expr<string> | string): Expr<boolean>;
   endsWith(s: Expr<string> | string, suffix: Expr<string> | string): Expr<boolean>;
   split(s: Expr<string> | string, delimiter: Expr<string> | string): Expr<string[]>;
   join(arr: Expr<string[]>, separator: Expr<string> | string): Expr<string>;
-  replace(s: Expr<string> | string, search: Expr<string> | string, replacement: Expr<string> | string): Expr<string>;
+  replace(
+    s: Expr<string> | string,
+    search: Expr<string> | string,
+    replacement: Expr<string> | string,
+  ): Expr<string>;
   len(s: Expr<string> | string): Expr<number>;
 }
 
 export const str: PluginDefinition<StrMethods> = {
   name: "str",
   nodeKinds: [
-    "str/template", "str/concat", "str/upper", "str/lower",
-    "str/trim", "str/slice", "str/includes", "str/startsWith",
-    "str/endsWith", "str/split", "str/join", "str/replace", "str/len",
+    "str/template",
+    "str/concat",
+    "str/upper",
+    "str/lower",
+    "str/trim",
+    "str/slice",
+    "str/includes",
+    "str/startsWith",
+    "str/endsWith",
+    "str/split",
+    "str/join",
+    "str/replace",
+    "str/len",
   ],
   build(ctx: PluginContext): StrMethods {
     return {

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ilo } from "../src/core";
 import { num } from "../src/plugins/num";
 import { str } from "../src/plugins/str";
@@ -40,9 +40,7 @@ describe("core: $.cond()", () => {
 
   it("produces a core/cond node with both branches via .t().f()", () => {
     const prog = app(($) => {
-      return $.cond($.eq($.input.x, 1))
-        .t($.add(1, 2))
-        .f($.add(3, 4));
+      return $.cond($.eq($.input.x, 1)).t($.add(1, 2)).f($.add(3, 4));
     });
     const ast = strip(prog.ast) as any;
     expect(ast.result.kind).toBe("core/cond");
@@ -52,9 +50,7 @@ describe("core: $.cond()", () => {
 
   it("works with .f().t() order", () => {
     const prog = app(($) => {
-      return $.cond($.eq($.input.x, 1))
-        .f($.add(3, 4))
-        .t($.add(1, 2));
+      return $.cond($.eq($.input.x, 1)).f($.add(3, 4)).t($.add(1, 2));
     });
     const ast = strip(prog.ast) as any;
     expect(ast.result.kind).toBe("core/cond");
@@ -191,10 +187,7 @@ describe("core: array methods produce core/lambda", () => {
 
   it(".reduce() produces core/lambda with accumulator and item params", () => {
     const prog = app(($) => {
-      return $.input.items.reduce(
-        (sum: any, item: any) => $.add(sum, item.price),
-        0
-      );
+      return $.input.items.reduce((sum: any, item: any) => $.add(sum, item.price), 0);
     });
     const ast = strip(prog.ast) as any;
     expect(ast.result.kind).toBe("core/method_call");

--- a/tests/plugins/error.test.ts
+++ b/tests/plugins/error.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ilo } from "../../src/core";
-import { num } from "../../src/plugins/num";
 import { error } from "../../src/plugins/error";
+import { num } from "../../src/plugins/num";
 import { postgres } from "../../src/plugins/postgres";
 
 function strip(ast: unknown): unknown {
   return JSON.parse(
-    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v))
+    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v)),
   );
 }
 
@@ -15,8 +15,10 @@ const app = ilo(num, postgres("postgres://localhost/test"), error);
 describe("error: $.try().catch()", () => {
   it("produces error/try with catch branch", () => {
     const prog = app(($) => {
-      return $.try($.sql`select * from users where id = ${$.input.id}`)
-        .catch((err) => ({ error: err.message, data: null }));
+      return $.try($.sql`select * from users where id = ${$.input.id}`).catch((err) => ({
+        error: err.message,
+        data: null,
+      }));
     });
     const ast = strip(prog.ast) as any;
     expect(ast.result.kind).toBe("error/try");
@@ -29,12 +31,11 @@ describe("error: $.try().catch()", () => {
 describe("error: $.try().match()", () => {
   it("produces error/try with match branches", () => {
     const prog = app(($) => {
-      return $.try($.sql`select * from users where id = ${$.input.id}`)
-        .match({
-          not_found: (_err) => "default_user",
-          timeout: (_err) => "cached_user",
-          _: (err) => $.fail(err),
-        });
+      return $.try($.sql`select * from users where id = ${$.input.id}`).match({
+        not_found: (_err) => "default_user",
+        timeout: (_err) => "cached_user",
+        _: (err) => $.fail(err),
+      });
     });
     const ast = strip(prog.ast) as any;
     expect(ast.result.kind).toBe("error/try");
@@ -75,10 +76,7 @@ describe("error: $.fail()", () => {
 describe("error: $.orElse()", () => {
   it("produces error/try with catch that returns fallback", () => {
     const prog = app(($) => {
-      return $.orElse(
-        $.sql`select * from users where id = ${$.input.id}`,
-        [{ name: "anonymous" }]
-      );
+      return $.orElse($.sql`select * from users where id = ${$.input.id}`, [{ name: "anonymous" }]);
     });
     const ast = strip(prog.ast) as any;
     expect(ast.result.kind).toBe("error/try");
@@ -109,7 +107,7 @@ describe("error: $.guard()", () => {
           message: "insufficient funds",
         }),
         $.sql`update accounts set balance = balance - ${$.input.amount}`,
-        { success: true }
+        { success: true },
       );
     });
     const ast = strip(prog.ast) as any;
@@ -126,7 +124,7 @@ describe("error: $.settle()", () => {
       return $.settle(
         $.sql`select 1 from users limit 1`,
         $.sql`select 1 from posts limit 1`,
-        $.sql`select 1 from comments limit 1`
+        $.sql`select 1 from comments limit 1`,
       );
     });
     const ast = strip(prog.ast) as any;

--- a/tests/plugins/num.test.ts
+++ b/tests/plugins/num.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ilo } from "../../src/core";
 import { num } from "../../src/plugins/num";
 

--- a/tests/plugins/postgres.test.ts
+++ b/tests/plugins/postgres.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ilo } from "../../src/core";
 import { num } from "../../src/plugins/num";
-import { str } from "../../src/plugins/str";
 import { postgres } from "../../src/plugins/postgres";
+import { str } from "../../src/plugins/str";
 
 function strip(ast: unknown): unknown {
   return JSON.parse(
-    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v))
+    JSON.stringify(ast, (k, v) => (k === "__id" || k === "config" ? undefined : v)),
   );
 }
 
@@ -149,10 +149,7 @@ describe("postgres: integration with $.do()", () => {
     expect(() => {
       app(($) => {
         const user = $.sql`select * from users where id = ${$.input.id}`;
-        return $.do(
-          $.sql`update users set last_seen = now() where id = ${$.input.id}`,
-          user[0]
-        );
+        return $.do($.sql`update users set last_seen = now() where id = ${$.input.id}`, user[0]);
       });
     }).not.toThrow();
   });

--- a/tests/plugins/str.test.ts
+++ b/tests/plugins/str.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ilo } from "../../src/core";
 import { str } from "../../src/plugins/str";
 


### PR DESCRIPTION
Closes #9

## What this does

Adds Biome for formatting and linting (single tool, fast), and a GitHub Actions CI workflow that runs format/lint check, typecheck, and tests on every PR to main. Also auto-fixes all existing formatting issues across the codebase and removes unused imports.

## Design alignment

- **VISION.md §6 (Testing Philosophy)**: CI now enforces the test suite on every PR, matching the "tests gate merges" principle.
- **CLAUDE.md standing rules**: Updated validation commands to reference `npm run check` and `npm test` instead of stale `npm run demo`.

## Validation performed

- `npm run build` — clean, no errors
- `npm run check` (biome) — 16 files checked, 0 issues
- `npm test` — 98 tests passing across 7 test files
- CI workflow validated against GitHub Actions schema

## Changes

- **biome.json**: Biome v2.3.14 config — 2-space indent, 100 line width, recommended rules with project-appropriate exceptions (noExplicitAny, noBannedTypes, noNonNullAssertion, noThenProperty, noAccumulatingSpread off)
- **.github/workflows/ci.yml**: Single job — checkout, setup Node 22, npm ci, format+lint, typecheck, test
- **package.json**: Added `check` and `format` scripts, added @biomejs/biome devDep
- **CLAUDE.md**: Updated validation commands
- **src/**, **tests/**: Auto-formatted by Biome, removed unused import (postgres.ts), fixed unused param (plugin-authoring-guide.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)