### PR TITLE
Implement recursion via Y combinator ($.rec)

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -70,9 +70,9 @@ After the closure executes, ilo walks the return tree and all emitted statements
 
 The DSL needs recursion for tree traversal, recursive data processing, and any program that can't be expressed as a flat map/filter/reduce. Native JS recursion doesn't work — a function calling itself would re-execute the closure and build a new AST.
 
-The approach: a Y combinator injected into the AST. Something like `$.rec(self => ...)` where `self` is a proxy representing "call this function again." The recursive call becomes an AST node (`core/rec_call`), and the interpreter implements the actual recursion. This keeps the AST finite and inspectable even for recursive programs.
+The approach: a Y combinator injected into the AST. `$.rec((self, n) => ...)` where `self` is a function that produces `core/rec_call` nodes and `n` is the input parameter. The recursive call becomes an AST node referencing the enclosing `core/rec` by ID, and the interpreter implements the actual recursion. This keeps the AST finite and inspectable even for recursive programs.
 
-**Status:** Not yet implemented. This is a core capability gap.
+**Status:** Implemented. `$.rec()` produces `core/rec` and `core/rec_call` nodes.
 
 ### Content hashing
 

--- a/tests/rec.test.ts
+++ b/tests/rec.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { ilo } from "../src/core";
+import { num } from "../src/plugins/num";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+const app = ilo(num);
+
+describe("rec: basic structure", () => {
+  it("produces core/rec with param and body", () => {
+    const prog = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(1)
+          .f($.mul(n, self($.sub(n, 1)))),
+      ),
+    );
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("core/rec");
+    expect(ast.result.param.kind).toBe("core/lambda_param");
+    expect(ast.result.param.name).toBe("rec_param");
+    expect(ast.result.body.kind).toBe("core/cond");
+  });
+
+  it("self() calls produce core/rec_call nodes", () => {
+    const prog = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(1)
+          .f($.mul(n, self($.sub(n, 1)))),
+      ),
+    );
+    const ast = strip(prog.ast) as any;
+    // The else branch is mul(n, self(sub(n,1)))
+    const elseBranch = ast.result.body.else;
+    expect(elseBranch.kind).toBe("num/mul");
+    expect(elseBranch.right.kind).toBe("core/rec_call");
+    expect(elseBranch.right.arg.kind).toBe("num/sub");
+  });
+
+  it("rec_call references the same recId as the rec node", () => {
+    const prog = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(1)
+          .f(self($.sub(n, 1))),
+      ),
+    );
+    const ast = strip(prog.ast) as any;
+    const recId = ast.result.recId;
+    expect(recId).toBeDefined();
+    expect(typeof recId).toBe("string");
+    // The else branch is the rec_call
+    const recCall = ast.result.body.else;
+    expect(recCall.kind).toBe("core/rec_call");
+    expect(recCall.recId).toBe(recId);
+  });
+});
+
+describe("rec: auto-lifting", () => {
+  it("self() auto-lifts raw values", () => {
+    const prog = app(($) => $.rec((_self, _n) => _self(42)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.body.kind).toBe("core/rec_call");
+    expect(ast.result.body.arg.kind).toBe("core/literal");
+    expect(ast.result.body.arg.value).toBe(42);
+  });
+});
+
+describe("rec: reachability", () => {
+  it("does not trigger orphan detection", () => {
+    // This should not throw — all nodes are reachable through the rec body
+    expect(() =>
+      app(($) =>
+        $.rec((self, n) =>
+          $.cond($.eq(n, 0))
+            .t(1)
+            .f($.mul(n, self($.sub(n, 1)))),
+        ),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("rec: content hashing", () => {
+  it("identical rec programs produce the same hash", () => {
+    const prog1 = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(1)
+          .f($.mul(n, self($.sub(n, 1)))),
+      ),
+    );
+    const prog2 = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(1)
+          .f($.mul(n, self($.sub(n, 1)))),
+      ),
+    );
+    expect(prog1.hash).toBe(prog2.hash);
+  });
+
+  it("different rec programs produce different hashes", () => {
+    const factorial = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(1)
+          .f($.mul(n, self($.sub(n, 1)))),
+      ),
+    );
+    const sum = app(($) =>
+      $.rec((self, n) =>
+        $.cond($.eq(n, 0))
+          .t(0)
+          .f($.add(n, self($.sub(n, 1)))),
+      ),
+    );
+    expect(factorial.hash).not.toBe(sum.hash);
+  });
+});


### PR DESCRIPTION
Closes #5

## What this does

Adds `$.rec((self, n) => ...)` to the core DSL for expressing recursive computations as finite ASTs. `self()` produces `core/rec_call` nodes that reference the enclosing `core/rec` by ID — the interpreter implements the actual recursion. Also strips `recId` from content hashing so identical recursive programs hash identically.

## Design alignment

- **VISION.md §3 (Recursion via Y combinator)**: Implementation matches the spec exactly — `$.rec` takes a callback with `self` and a single param, `self(arg)` produces `core/rec_call` nodes, the AST stays finite. Updated VISION.md status from "Not yet implemented" to "Implemented."

## Validation performed

- `npm run build` — clean, no errors
- `npm run check` — 17 files, 0 issues
- `npm test` — 105 tests passing (98 existing + 7 new rec tests)
- Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)