### PR TITLE
Extract non-primitive core ops into boolean, control, st plugins

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -97,6 +97,9 @@ The AST (with internal IDs stripped) is hashed to produce a deterministic progra
 |--------|-----------|-------------------|
 | `num` | `num/` | Arithmetic (`add`, `sub`, `mul`, `div`, `mod`), comparison (`gt`, `gte`, `lt`, `lte`), rounding (`floor`, `ceil`, `round`, `abs`), variadic (`min`, `max`), negation |
 | `str` | `str/` | Tagged template `` $.str`...` ``, `concat`, `upper`, `lower`, `trim`, `slice`, `includes`, `startsWith`, `endsWith`, `split`, `join`, `replace`, `len` |
+| `boolean` | `boolean/` | Logical operators (`and`, `or`, `not`). Sugar over `$.cond` but with dedicated AST nodes for clarity. |
+| `control` | `control/` | Imperative control flow (`each`, `while`). Expressible via `$.rec` but provided as ergonomic primitives. |
+| `st` | `st/` | Mutable state (ST monad). `$.let(initial)` returns `.get()`, `.set()`, `.push()`. Scoped mutable bindings for imperative accumulation patterns. |
 | `fiber` | `fiber/` | Concurrency primitives. Parallel execution (`par` — tuple and bounded map forms), sequential (`seq`), first-wins (`race`), `timeout` with fallback, `retry` with attempts/delay. Concurrency limits are always explicit. |
 | `error` | `error/` | Structured error handling. `try`/`.catch`/`.match`/`.finally`, explicit failure (`fail`), default-on-error (`orElse`), Either-style (`attempt`), assertions (`guard`), collect-all (`settle`). |
 
@@ -134,7 +137,10 @@ The resulting `$` is the intersection of all plugin contributions. A `postgres/q
 ```
 Layer       Plugin     Provides           PureScript equivalent
 ─────       ──────     ────────           ─────────────────────
-pure        core       $.do, $.cond       Identity
+pure        core       $.do, $.cond, $.rec Identity
+logic       boolean    $.and, $.or, $.not Boolean combinators
+state       st         $.let, .get, .set  ST
+control     control    $.each, $.while    Control.Monad
 concurrency fiber      $.par, $.retry     Aff
 failure     error      $.try, $.guard     ExceptT
 database    postgres   $.sql`...`         postgres FFI

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,19 @@
 
 export type { ASTNode, Expr, Plugin, PluginContext, PluginDefinition, Program } from "./core";
 export { ilo } from "./core";
+export type { BooleanMethods } from "./plugins/boolean";
+export { boolean } from "./plugins/boolean";
+export type { ControlMethods } from "./plugins/control";
+export { control } from "./plugins/control";
 export type { ErrorMethods } from "./plugins/error";
 export { error } from "./plugins/error";
 export type { FiberMethods } from "./plugins/fiber";
 export { fiber } from "./plugins/fiber";
 export type { NumMethods } from "./plugins/num";
-// Structural plugins
 export { num } from "./plugins/num";
 export type { PostgresConfig, PostgresMethods } from "./plugins/postgres";
-// Real-world plugins
 export { postgres } from "./plugins/postgres";
+export type { StMethods } from "./plugins/st";
+export { st } from "./plugins/st";
 export type { StrMethods } from "./plugins/str";
 export { str } from "./plugins/str";

--- a/src/plugins/boolean.ts
+++ b/src/plugins/boolean.ts
@@ -1,0 +1,25 @@
+import type { Expr, PluginContext, PluginDefinition } from "../core";
+
+export interface BooleanMethods {
+  and(a: Expr<boolean>, b: Expr<boolean>): Expr<boolean>;
+  or(a: Expr<boolean>, b: Expr<boolean>): Expr<boolean>;
+  not(a: Expr<boolean>): Expr<boolean>;
+}
+
+export const boolean: PluginDefinition<BooleanMethods> = {
+  name: "boolean",
+  nodeKinds: ["boolean/and", "boolean/or", "boolean/not"],
+  build(ctx: PluginContext): BooleanMethods {
+    return {
+      and(a, b) {
+        return ctx.expr<boolean>({ kind: "boolean/and", left: a.__node, right: b.__node });
+      },
+      or(a, b) {
+        return ctx.expr<boolean>({ kind: "boolean/or", left: a.__node, right: b.__node });
+      },
+      not(a) {
+        return ctx.expr<boolean>({ kind: "boolean/not", operand: a.__node });
+      },
+    };
+  },
+};

--- a/src/plugins/control.ts
+++ b/src/plugins/control.ts
@@ -1,0 +1,42 @@
+import type { ASTNode, Expr, PluginContext, PluginDefinition } from "../core";
+
+export interface ControlMethods {
+  each<T>(collection: Expr<T[]>, body: (item: Expr<T>) => void): void;
+  while(condition: Expr<boolean>): {
+    body: (...statements: unknown[]) => void;
+  };
+}
+
+export const control: PluginDefinition<ControlMethods> = {
+  name: "control",
+  nodeKinds: ["control/each", "control/while"],
+  build(ctx: PluginContext): ControlMethods {
+    return {
+      each<T>(collection: Expr<T[]>, body: (item: Expr<T>) => void) {
+        const paramNode: ASTNode = { kind: "core/lambda_param", name: "item" };
+        const paramProxy = ctx.expr<T>(paramNode) as Expr<T>;
+        const prevLen = ctx.statements.length;
+        body(paramProxy);
+        const bodyStatements = ctx.statements.splice(prevLen);
+        ctx.emit({
+          kind: "control/each",
+          collection: collection.__node,
+          param: paramNode,
+          body: bodyStatements,
+        });
+      },
+
+      while(condition: Expr<boolean>) {
+        return {
+          body: (...stmts: unknown[]) => {
+            ctx.emit({
+              kind: "control/while",
+              condition: condition.__node,
+              body: stmts.filter((s) => ctx.isExpr(s)).map((s) => (s as Expr<unknown>).__node),
+            });
+          },
+        };
+      },
+    };
+  },
+};

--- a/src/plugins/st.ts
+++ b/src/plugins/st.ts
@@ -1,0 +1,41 @@
+import type { Expr, PluginContext, PluginDefinition } from "../core";
+
+export interface StMethods {
+  let<T>(initial: Expr<T> | T): {
+    get: () => Expr<T>;
+    set: (value: Expr<T> | T) => void;
+    push: (value: Expr<T>) => void;
+  };
+}
+
+export const st: PluginDefinition<StMethods> = {
+  name: "st",
+  nodeKinds: ["st/let", "st/get", "st/set", "st/push"],
+  build(ctx: PluginContext): StMethods {
+    let refCounter = 0;
+
+    return {
+      let<T>(initial: Expr<T> | T) {
+        const ref = `st_${refCounter++}`;
+        const initNode = ctx.lift(initial).__node;
+        ctx.emit({ kind: "st/let", ref, initial: initNode });
+
+        return {
+          get: () => ctx.expr<T>({ kind: "st/get", ref }),
+          set: (value: Expr<T> | T) =>
+            ctx.emit({
+              kind: "st/set",
+              ref,
+              value: ctx.lift(value).__node,
+            }),
+          push: (value: Expr<T>) =>
+            ctx.emit({
+              kind: "st/push",
+              ref,
+              value: value.__node,
+            }),
+        };
+      },
+    };
+  },
+};

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -70,7 +70,7 @@ describe("core: $.cond()", () => {
   });
 });
 
-describe("core: $.eq(), $.and(), $.or(), $.not()", () => {
+describe("core: $.eq()", () => {
   const app = ilo(num);
 
   it("$.eq produces core/eq", () => {
@@ -79,25 +79,6 @@ describe("core: $.eq(), $.and(), $.or(), $.not()", () => {
     expect(ast.result.kind).toBe("core/eq");
     expect(ast.result.right.kind).toBe("core/literal");
     expect(ast.result.right.value).toBe(1);
-  });
-
-  it("$.and produces core/and", () => {
-    const prog = app(($) => $.and($.eq($.input.x, 1), $.eq($.input.y, 2)));
-    const ast = strip(prog.ast) as any;
-    expect(ast.result.kind).toBe("core/and");
-  });
-
-  it("$.or produces core/or", () => {
-    const prog = app(($) => $.or($.eq($.input.x, 1), $.eq($.input.y, 2)));
-    const ast = strip(prog.ast) as any;
-    expect(ast.result.kind).toBe("core/or");
-  });
-
-  it("$.not produces core/not", () => {
-    const prog = app(($) => $.not($.eq($.input.x, 1)));
-    const ast = strip(prog.ast) as any;
-    expect(ast.result.kind).toBe("core/not");
-    expect(ast.result.operand.kind).toBe("core/eq");
   });
 });
 
@@ -252,11 +233,11 @@ describe("core: reachability analysis", () => {
     }).not.toThrow();
   });
 
-  it("does not false-positive on $.input or $.noop", () => {
+  it("does not false-positive on $.input", () => {
     expect(() => {
       app(($) => {
         $.input.unused; // accessing input doesn't create orphans
-        return $.noop;
+        return $.input.x;
       });
     }).not.toThrow();
   });

--- a/tests/plugins/boolean.test.ts
+++ b/tests/plugins/boolean.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { ilo } from "../../src/core";
+import { boolean } from "../../src/plugins/boolean";
+import { num } from "../../src/plugins/num";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+const app = ilo(num, boolean);
+
+describe("boolean: $.and()", () => {
+  it("produces boolean/and", () => {
+    const prog = app(($) => $.and($.eq($.input.x, 1), $.eq($.input.y, 2)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("boolean/and");
+    expect(ast.result.left.kind).toBe("core/eq");
+    expect(ast.result.right.kind).toBe("core/eq");
+  });
+});
+
+describe("boolean: $.or()", () => {
+  it("produces boolean/or", () => {
+    const prog = app(($) => $.or($.eq($.input.x, 1), $.eq($.input.y, 2)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("boolean/or");
+    expect(ast.result.left.kind).toBe("core/eq");
+    expect(ast.result.right.kind).toBe("core/eq");
+  });
+});
+
+describe("boolean: $.not()", () => {
+  it("produces boolean/not", () => {
+    const prog = app(($) => $.not($.eq($.input.x, 1)));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("boolean/not");
+    expect(ast.result.operand.kind).toBe("core/eq");
+  });
+});

--- a/tests/plugins/control.test.ts
+++ b/tests/plugins/control.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ilo } from "../../src/core";
+import { control } from "../../src/plugins/control";
+import { num } from "../../src/plugins/num";
+import { st } from "../../src/plugins/st";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+describe("control: $.each()", () => {
+  const app = ilo(num, st, control);
+
+  it("produces control/each with collection and body", () => {
+    const prog = app(($) => {
+      const sum = $.let(0);
+      $.each($.input.items, (item: any) => {
+        sum.set($.add(sum.get(), item.value));
+      });
+      return sum.get();
+    });
+    const ast = strip(prog.ast) as any;
+    const eachNode = ast.statements.find((s: any) => s.kind === "control/each");
+    expect(eachNode).toBeDefined();
+    expect(eachNode.param.kind).toBe("core/lambda_param");
+    expect(eachNode.body).toHaveLength(1);
+  });
+});
+
+describe("control: $.while()", () => {
+  const app = ilo(num, st, control);
+
+  it("produces control/while with condition and body", () => {
+    const prog = app(($) => {
+      const counter = $.let(0);
+      $.while($.lt(counter.get(), 10)).body(counter.set($.add(counter.get(), 1)));
+      return counter.get();
+    });
+    const ast = strip(prog.ast) as any;
+    const whileNode = ast.statements.find((s: any) => s.kind === "control/while");
+    expect(whileNode).toBeDefined();
+    expect(whileNode.condition.kind).toBe("num/lt");
+  });
+});

--- a/tests/plugins/st.test.ts
+++ b/tests/plugins/st.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { ilo } from "../../src/core";
+import { num } from "../../src/plugins/num";
+import { st } from "../../src/plugins/st";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+const app = ilo(num, st);
+
+describe("st: $.let()", () => {
+  it("emits st/let statement and st/get returns proxy", () => {
+    const prog = app(($) => {
+      const x = $.let(0);
+      return x.get();
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.statements[0].kind).toBe("st/let");
+    expect(ast.statements[0].initial.kind).toBe("core/literal");
+    expect(ast.statements[0].initial.value).toBe(0);
+    expect(ast.result.kind).toBe("st/get");
+  });
+
+  it("$.let().set() emits st/set statement", () => {
+    const prog = app(($) => {
+      const x = $.let(0);
+      x.set($.add(x.get(), 1));
+      return x.get();
+    });
+    const ast = strip(prog.ast) as any;
+    const setStmt = ast.statements.find((s: any) => s.kind === "st/set");
+    expect(setStmt).toBeDefined();
+    expect(setStmt.value.kind).toBe("num/add");
+  });
+
+  it("$.let().push() emits st/push statement", () => {
+    const prog = app(($) => {
+      const arr = $.let([]);
+      arr.push($.input.item);
+      return arr.get();
+    });
+    const ast = strip(prog.ast) as any;
+    const pushStmt = ast.statements.find((s: any) => s.kind === "st/push");
+    expect(pushStmt).toBeDefined();
+  });
+
+  it("auto-lifts initial value", () => {
+    const prog = app(($) => {
+      const x = $.let("hello");
+      return x.get();
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.statements[0].initial.kind).toBe("core/literal");
+    expect(ast.statements[0].initial.value).toBe("hello");
+  });
+});


### PR DESCRIPTION
Closes #15

## What this does

Moves non-primitive operations out of core into three new plugins: `boolean` (and/or/not), `control` (while/each), and `st` (let/get/set/push — the ST monad). Removes `$.noop`. After this change, core is irreducible: `$.input`, `$.cond`, `$.eq`, `$.do`, `$.rec`, and the proxy system (prop_access, method_call, lambda, auto-lifting).

## Design alignment

- **VISION.md §3**: Core is now truly irreducible — only primitives that can't be expressed in terms of other core operations remain.
- **VISION.md §5**: Updated plugin table with three new structural plugins, updated monad stack table.
- **Plugin contract**: All three new plugins follow the `{ name, nodeKinds, build(ctx) }` contract. Node kinds are namespaced (`boolean/and`, `control/each`, `st/let`, etc.).

## Validation performed

- `npm run build` — clean, no errors
- `npm run check` — 23 files, 0 issues
- `npm test` — 111 tests passing across 11 test files (was 105 across 8)
- Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)