### PR TITLE
feat(plugin-anthropic): align public method types with Anthropic SDK

### DIFF
--- a/packages/plugin-anthropic/etc/plugin-anthropic.api.json
+++ b/packages/plugin-anthropic/etc/plugin-anthropic.api.json
@@ -488,39 +488,21 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageCreateParamsNonStreaming",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageCreateParamsNonStreaming:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>> | "
+                  "text": "> | "
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageCreateParamsNonStreaming",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageCreateParamsNonStreaming:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Expr",
-                  "canonicalReference": "@mvfm/plugin-anthropic!~Expr:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<string, unknown>>;\n            countTokens(params: "
+                  "text": "): "
                 },
                 {
                   "kind": "Reference",
@@ -533,21 +515,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "Message",
+                  "canonicalReference": "@anthropic-ai/sdk!Message:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>> | "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<string, unknown>): "
+                  "text": ">;\n            countTokens(params: "
                 },
                 {
                   "kind": "Reference",
@@ -560,12 +533,21 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageCountTokensParams",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageCountTokensParams:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n            batches: {\n                create(params: "
+                  "text": "> | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "MessageCountTokensParams",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageCountTokensParams:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
                 },
                 {
                   "kind": "Reference",
@@ -578,21 +560,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageTokensCount",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageTokensCount:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>> | "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<string, unknown>): "
+                  "text": ">;\n            batches: {\n                create(params: "
                 },
                 {
                   "kind": "Reference",
@@ -605,12 +578,39 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "BatchCreateParams",
+                  "canonicalReference": "@anthropic-ai/sdk!BatchCreateParams:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n                retrieve(id: "
+                  "text": "> | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BatchCreateParams",
+                  "canonicalReference": "@anthropic-ai/sdk!BatchCreateParams:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Expr",
+                  "canonicalReference": "@mvfm/plugin-anthropic!~Expr:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "MessageBatch",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageBatch:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">;\n                retrieve(id: "
                 },
                 {
                   "kind": "Reference",
@@ -632,12 +632,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageBatch",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageBatch:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n                list(params?: "
+                  "text": ">;\n                list(params?: "
                 },
                 {
                   "kind": "Reference",
@@ -650,21 +650,21 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "BatchListParams",
+                  "canonicalReference": "@anthropic-ai/sdk!BatchListParams:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>> | "
+                  "text": "> | "
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "BatchListParams",
+                  "canonicalReference": "@anthropic-ai/sdk!BatchListParams:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>): "
+                  "text": "): "
                 },
                 {
                   "kind": "Reference",
@@ -677,12 +677,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageBatchesPage",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageBatchesPage:type"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n                delete(id: "
+                  "text": ">;\n                delete(id: "
                 },
                 {
                   "kind": "Reference",
@@ -704,12 +704,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "DeletedMessageBatch",
+                  "canonicalReference": "@anthropic-ai/sdk!DeletedMessageBatch:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n                cancel(id: "
+                  "text": ">;\n                cancel(id: "
                 },
                 {
                   "kind": "Reference",
@@ -731,12 +731,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "MessageBatch",
+                  "canonicalReference": "@anthropic-ai/sdk!MessageBatch:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n            };\n        };\n        models: {\n            retrieve(id: "
+                  "text": ">;\n            };\n        };\n        models: {\n            retrieve(id: "
                 },
                 {
                   "kind": "Reference",
@@ -758,12 +758,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "ModelInfo",
+                  "canonicalReference": "@anthropic-ai/sdk!ModelInfo:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n            list(params?: "
+                  "text": ">;\n            list(params?: "
                 },
                 {
                   "kind": "Reference",
@@ -776,21 +776,21 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "ModelListParams",
+                  "canonicalReference": "@anthropic-ai/sdk!ModelListParams:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>> | "
+                  "text": "> | "
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "ModelListParams",
+                  "canonicalReference": "@anthropic-ai/sdk!ModelListParams:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>): "
+                  "text": "): "
                 },
                 {
                   "kind": "Reference",
@@ -803,12 +803,12 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Record",
-                  "canonicalReference": "!Record:type"
+                  "text": "ModelInfosPage",
+                  "canonicalReference": "@anthropic-ai/sdk!ModelInfosPage:type"
                 },
                 {
                   "kind": "Content",
-                  "text": "<string, unknown>>;\n        };\n    }"
+                  "text": ">;\n        };\n    }"
                 },
                 {
                   "kind": "Content",

--- a/packages/plugin-anthropic/etc/plugin-anthropic.api.md
+++ b/packages/plugin-anthropic/etc/plugin-anthropic.api.md
@@ -5,6 +5,18 @@
 ```ts
 
 import type Anthropic from '@anthropic-ai/sdk';
+import type { BatchCreateParams } from '@anthropic-ai/sdk/resources/messages/batches';
+import type { BatchListParams } from '@anthropic-ai/sdk/resources/messages/batches';
+import type { DeletedMessageBatch } from '@anthropic-ai/sdk/resources/messages/batches';
+import type { Message } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { MessageBatch } from '@anthropic-ai/sdk/resources/messages/batches';
+import type { MessageBatchesPage } from '@anthropic-ai/sdk/resources/messages/batches';
+import type { MessageCountTokensParams } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { MessageCreateParamsNonStreaming } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { MessageTokensCount } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { ModelInfo } from '@anthropic-ai/sdk/resources/models';
+import type { ModelInfosPage } from '@anthropic-ai/sdk/resources/models';
+import type { ModelListParams } from '@anthropic-ai/sdk/resources/models';
 
 // Warning: (ae-forgotten-export) The symbol "PluginDefinition" needs to be exported by the entry point index.d.ts
 //
@@ -31,19 +43,19 @@ export const anthropicInterpreter: InterpreterFragment;
 export interface AnthropicMethods {
     anthropic: {
         messages: {
-            create(params: Expr<Record<string, unknown>> | Record<string, unknown>): Expr<Record<string, unknown>>;
-            countTokens(params: Expr<Record<string, unknown>> | Record<string, unknown>): Expr<Record<string, unknown>>;
+            create(params: Expr<MessageCreateParamsNonStreaming> | MessageCreateParamsNonStreaming): Expr<Message>;
+            countTokens(params: Expr<MessageCountTokensParams> | MessageCountTokensParams): Expr<MessageTokensCount>;
             batches: {
-                create(params: Expr<Record<string, unknown>> | Record<string, unknown>): Expr<Record<string, unknown>>;
-                retrieve(id: Expr<string> | string): Expr<Record<string, unknown>>;
-                list(params?: Expr<Record<string, unknown>> | Record<string, unknown>): Expr<Record<string, unknown>>;
-                delete(id: Expr<string> | string): Expr<Record<string, unknown>>;
-                cancel(id: Expr<string> | string): Expr<Record<string, unknown>>;
+                create(params: Expr<BatchCreateParams> | BatchCreateParams): Expr<MessageBatch>;
+                retrieve(id: Expr<string> | string): Expr<MessageBatch>;
+                list(params?: Expr<BatchListParams> | BatchListParams): Expr<MessageBatchesPage>;
+                delete(id: Expr<string> | string): Expr<DeletedMessageBatch>;
+                cancel(id: Expr<string> | string): Expr<MessageBatch>;
             };
         };
         models: {
-            retrieve(id: Expr<string> | string): Expr<Record<string, unknown>>;
-            list(params?: Expr<Record<string, unknown>> | Record<string, unknown>): Expr<Record<string, unknown>>;
+            retrieve(id: Expr<string> | string): Expr<ModelInfo>;
+            list(params?: Expr<ModelListParams> | ModelListParams): Expr<ModelInfosPage>;
         };
     };
 }
@@ -79,7 +91,7 @@ export function wrapAnthropicSdk(client: Anthropic): AnthropicClient;
 
 // Warnings were encountered during analysis:
 //
-// dist/0.74.0/index.d.ts:15:13 - (ae-forgotten-export) The symbol "Expr" needs to be exported by the entry point index.d.ts
+// dist/0.74.0/index.d.ts:18:13 - (ae-forgotten-export) The symbol "Expr" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 


### PR DESCRIPTION
Closes #76

## What this does
This updates `@mvfm/plugin-anthropic` public method signatures to use concrete `@anthropic-ai/sdk` request/response types instead of `Record<string, unknown>`. `messages`, `message batches`, and `models` methods now expose SDK-aligned params and return shapes for stronger static typing and better editor support. The plugin runtime/interpreter behavior is unchanged.

## Design alignment
No VISION.md principles were explicitly referenced in #76.

## Validation performed
- `npm run build` (pass)
- `npm run check` (pass)
- `npm test` (fails outside this issue scope: `@mvfm/plugin-postgres` requires container runtime via testcontainers in this environment)
- During `npm test`, `@mvfm/plugin-anthropic` suite passed before the run halted on postgres container runtime failures.
