### PR TITLE
Stabilize plugin-s3 CI with workflow-managed LocalStack endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,14 @@ jobs:
       - name: Check (lint + typecheck + api-extractor)
         run: pnpm run check
 
+      - name: Start LocalStack
+        uses: LocalStack/setup-localstack@v0.2.2
+        with:
+          image-tag: latest
+
       - name: Test
+        env:
+          MVFM_S3_ENDPOINT: http://localhost:4566
         run: pnpm run test
 
   size:


### PR DESCRIPTION
Closes #126

## What this does
This updates CI to start LocalStack in GitHub Actions before tests and injects `MVFM_S3_ENDPOINT` for the test run. The plugin-s3 integration test now prefers a provided endpoint in CI, but still falls back to Testcontainers locally when no endpoint is provided. Teardown is also hardened so cleanup is safe when setup is partial or fails.

## Design alignment
The issue does not reference specific `VISION.md` principles. This change remains narrowly scoped to CI/test stability and does not alter DSL semantics, AST contracts, or plugin API shape.

## Validation performed
- `pnpm run build` (pass)
- `pnpm run check` (pass)
- `pnpm run test` (pass)
