### PR TITLE
feat(plugin-zod): parsing operations (parseAsync, safeParseAsync)

### DIFF
--- a/packages/plugin-zod/src/base.ts
+++ b/packages/plugin-zod/src/base.ts
@@ -126,14 +126,9 @@ export abstract class ZodSchemaBuilder<T> {
     }) as this;
   }
 
-  // ---- Parsing operations (implemented by #96) ----
-  // Stubs declared here so TypeScript knows about them.
-  // #96 will provide the actual implementation.
+  // ---- Parsing operations (#96) ----
 
-  /**
-   * Validate input and return data or throw. Produces `zod/parse` AST node.
-   * @stub Implemented by #96
-   */
+  /** Validate input and return data or throw. Produces `zod/parse` AST node. */
   parse(input: Expr<unknown> | unknown): Expr<T> {
     return this._ctx.expr<T>({
       kind: "zod/parse",
@@ -142,13 +137,30 @@ export abstract class ZodSchemaBuilder<T> {
     });
   }
 
-  /**
-   * Validate input and return result object. Produces `zod/safe_parse` AST node.
-   * @stub Implemented by #96
-   */
+  /** Validate input and return result object. Produces `zod/safe_parse` AST node. */
   safeParse(input: Expr<unknown> | unknown): Expr<{ success: boolean; data: T; error: unknown }> {
     return this._ctx.expr<{ success: boolean; data: T; error: unknown }>({
       kind: "zod/safe_parse",
+      schema: this._buildSchemaNode(),
+      input: this._ctx.lift(input).__node,
+    });
+  }
+
+  /** Async variant of `parse`. Produces `zod/parse_async` AST node. */
+  parseAsync(input: Expr<unknown> | unknown): Expr<Promise<T>> {
+    return this._ctx.expr<Promise<T>>({
+      kind: "zod/parse_async",
+      schema: this._buildSchemaNode(),
+      input: this._ctx.lift(input).__node,
+    });
+  }
+
+  /** Async variant of `safeParse`. Produces `zod/safe_parse_async` AST node. */
+  safeParseAsync(
+    input: Expr<unknown> | unknown,
+  ): Expr<Promise<{ success: boolean; data: T; error: unknown }>> {
+    return this._ctx.expr<Promise<{ success: boolean; data: T; error: unknown }>>({
+      kind: "zod/safe_parse_async",
       schema: this._buildSchemaNode(),
       input: this._ctx.lift(input).__node,
     });

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -124,4 +124,25 @@ describe("ZodSchemaBuilder base class", () => {
       value: 100,
     });
   });
+
+  it("parseAsync() produces zod/parse_async AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.string().parseAsync($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("zod/parse_async");
+    expect(ast.result.schema.kind).toBe("zod/string");
+    expect(ast.result.input).toBeDefined();
+  });
+
+  it("safeParseAsync() produces zod/safe_parse_async AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.string().safeParseAsync($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.kind).toBe("zod/safe_parse_async");
+    expect(ast.result.schema.kind).toBe("zod/string");
+  });
 });


### PR DESCRIPTION
Closes #96

## What this does

Adds `parseAsync()` and `safeParseAsync()` async parsing terminal operations to `ZodSchemaBuilder<T>`. The sync variants (`parse`, `safeParse`) were already implemented as stubs in #95; this completes the full set and removes stub markers.

## Design alignment

- **Plugin contract**: Node kinds `zod/parse_async` and `zod/safe_parse_async` already declared in `nodeKinds` from #95. ✅
- **AST namespacing**: All node kinds prefixed `zod/`. ✅
- **Base class pattern**: All four methods live on the base class, inherited by all schema subclasses. ✅

## Validation performed

```
pnpm --filter @mvfm/core run build    # ✅ core builds
pnpm --filter @mvfm/plugin-zod run check  # ✅ biome + tsc clean
pnpm --filter @mvfm/plugin-zod run test   # ✅ 12/12 tests pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)