### PR TITLE
feat: add zodInterpreter with parsing operations (#133)

### DIFF
--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -1,8 +1,9 @@
 import type { PluginDefinition } from "@mvfm/core";
 import { ZodStringBuilder } from "./string";
 
-// Re-export types and builders for consumers
+// Re-export types, builders, and interpreter for consumers
 export { ZodSchemaBuilder, ZodWrappedBuilder } from "./base";
+export { zodInterpreter } from "./interpreter";
 export { ZodStringBuilder } from "./string";
 export type {
   CheckDescriptor,

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -1,0 +1,81 @@
+import type { ASTNode, InterpreterFragment, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import type { CheckDescriptor } from "./types";
+
+/**
+ * Apply check descriptors to a Zod string schema.
+ * Each check kind maps to the corresponding Zod method.
+ */
+function applyStringChecks(schema: z.ZodString, checks: CheckDescriptor[]): z.ZodString {
+  let s = schema;
+  for (const check of checks) {
+    switch (check.kind) {
+      case "min_length":
+        s = s.min(check.value as number);
+        break;
+      case "max_length":
+        s = s.max(check.value as number);
+        break;
+      // Additional string checks will be added by #137
+      default:
+        throw new Error(`Zod interpreter: unknown string check "${check.kind}"`);
+    }
+  }
+  return s;
+}
+
+/**
+ * Build a Zod schema from a schema AST node.
+ * Dispatches on node.kind to construct the appropriate Zod type.
+ */
+function buildSchema(node: ASTNode): z.ZodType {
+  switch (node.kind) {
+    case "zod/string": {
+      const checks = (node.checks as CheckDescriptor[]) ?? [];
+      return applyStringChecks(z.string(), checks);
+    }
+    // Additional schema types will be added by colocated interpreter issues
+    default:
+      throw new Error(`Zod interpreter: unknown schema kind "${node.kind}"`);
+  }
+}
+
+/**
+ * Interpreter fragment for `zod/` node kinds.
+ *
+ * Handles parsing operation nodes by recursing into schema + input,
+ * reconstructing the Zod schema from AST, and executing validation.
+ *
+ * Schema nodes (zod/string, etc.) are handled by `buildSchema` which
+ * constructs actual Zod schemas from AST descriptors.
+ */
+export const zodInterpreter: InterpreterFragment = {
+  pluginName: "zod",
+  canHandle: (node) => node.kind.startsWith("zod/"),
+  *visit(node: ASTNode): Generator<StepEffect, unknown, unknown> {
+    switch (node.kind) {
+      case "zod/parse": {
+        const schema = buildSchema(node.schema as ASTNode);
+        const input = yield { type: "recurse", child: node.input as ASTNode };
+        return schema.parse(input);
+      }
+      case "zod/safe_parse": {
+        const schema = buildSchema(node.schema as ASTNode);
+        const input = yield { type: "recurse", child: node.input as ASTNode };
+        return schema.safeParse(input);
+      }
+      case "zod/parse_async": {
+        const schema = buildSchema(node.schema as ASTNode);
+        const input = yield { type: "recurse", child: node.input as ASTNode };
+        return schema.parseAsync(input);
+      }
+      case "zod/safe_parse_async": {
+        const schema = buildSchema(node.schema as ASTNode);
+        const input = yield { type: "recurse", child: node.input as ASTNode };
+        return schema.safeParseAsync(input);
+      }
+      default:
+        throw new Error(`Zod interpreter: unknown node kind "${node.kind}"`);
+    }
+  },
+};

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -1,0 +1,101 @@
+import { composeInterpreters, coreInterpreter, mvfm } from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { zod, zodInterpreter } from "../src/index";
+
+/** Inject input data into core/input nodes throughout the AST. */
+function injectInput(node: any, input: Record<string, unknown>): any {
+  if (node === null || node === undefined || typeof node !== "object") return node;
+  if (Array.isArray(node)) return node.map((n) => injectInput(n, input));
+  const result: any = {};
+  for (const [k, v] of Object.entries(node)) {
+    result[k] = injectInput(v, input);
+  }
+  if (result.kind === "core/input") result.__inputData = input;
+  return result;
+}
+
+/** Build AST from DSL, inject input, compose interpreters, evaluate. */
+async function run(prog: { ast: any }, input: Record<string, unknown> = {}) {
+  const ast = injectInput(prog.ast, input);
+  const interp = composeInterpreters([coreInterpreter, zodInterpreter]);
+  return await interp(ast.result);
+}
+
+const app = mvfm(zod);
+
+describe("zodInterpreter: parse operations (#133)", () => {
+  it("parse() validates valid string input", async () => {
+    const prog = app(($) => $.zod.string().parse($.input.value));
+    expect(await run(prog, { value: "hello" })).toBe("hello");
+  });
+
+  it("parse() throws on invalid input", async () => {
+    const prog = app(($) => $.zod.string().parse($.input.value));
+    await expect(run(prog, { value: 42 })).rejects.toThrow();
+  });
+
+  it("safeParse() returns success for valid input", async () => {
+    const prog = app(($) => $.zod.string().safeParse($.input.value));
+    const result = (await run(prog, { value: "hello" })) as any;
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("hello");
+  });
+
+  it("safeParse() returns failure for invalid input", async () => {
+    const prog = app(($) => $.zod.string().safeParse($.input.value));
+    const result = (await run(prog, { value: 123 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("parseAsync() validates valid input", async () => {
+    const prog = app(($) => $.zod.string().parseAsync($.input.value));
+    expect(await run(prog, { value: "async-hello" })).toBe("async-hello");
+  });
+
+  it("parseAsync() throws on invalid input", async () => {
+    const prog = app(($) => $.zod.string().parseAsync($.input.value));
+    await expect(run(prog, { value: false })).rejects.toThrow();
+  });
+
+  it("safeParseAsync() returns success for valid input", async () => {
+    const prog = app(($) => $.zod.string().safeParseAsync($.input.value));
+    const result = (await run(prog, { value: "ok" })) as any;
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("ok");
+  });
+
+  it("safeParseAsync() returns failure for invalid input", async () => {
+    const prog = app(($) => $.zod.string().safeParseAsync($.input.value));
+    const result = (await run(prog, { value: null })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("string checks: min_length rejects short strings", async () => {
+    const prog = app(($) => $.zod.string().min(5).safeParse($.input.value));
+    const result = (await run(prog, { value: "hi" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("string checks: min_length accepts valid strings", async () => {
+    const prog = app(($) => $.zod.string().min(5).safeParse($.input.value));
+    const result = (await run(prog, { value: "hello world" })) as any;
+    expect(result.success).toBe(true);
+  });
+
+  it("string checks: max_length rejects long strings", async () => {
+    const prog = app(($) => $.zod.string().max(3).safeParse($.input.value));
+    const result = (await run(prog, { value: "toolong" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("chained min + max checks work together", async () => {
+    const prog = app(($) => $.zod.string().min(2).max(5).safeParse($.input.value));
+    const tooShort = (await run(prog, { value: "a" })) as any;
+    const justRight = (await run(prog, { value: "abc" })) as any;
+    const tooLong = (await run(prog, { value: "abcdefg" })) as any;
+    expect(tooShort.success).toBe(false);
+    expect(justRight.success).toBe(true);
+    expect(tooLong.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #133

## What this does

Creates the `zodInterpreter` InterpreterFragment for the zod plugin, implementing interpretation for all four parsing operation node kinds (`zod/parse`, `zod/safe_parse`, `zod/parse_async`, `zod/safe_parse_async`). The interpreter reconstructs actual Zod schemas from AST descriptors and executes validation against runtime input. Also handles `min_length` and `max_length` string checks as part of schema reconstruction.

## Design alignment

- **Generator-based InterpreterFragment**: Follows the exact same pattern as `numInterpreter`, `strInterpreter`, etc. — `canHandle` + `*visit` generator with `yield { type: "recurse", child }` for child evaluation.
- **AST-first round-trip**: Tests verify the full pipeline: DSL → AST → compose interpreters → evaluate → correct validation results.
- **Plugin contract**: `zodInterpreter` exported from `src/index.ts` alongside the plugin definition.

## Validation performed

- `pnpm --filter @mvfm/plugin-zod run check` — biome lint + tsc clean
- `pnpm --filter @mvfm/plugin-zod test` — 48/48 tests pass (36 existing AST tests + 12 new interpreter round-trip tests)
- Tests cover: valid/invalid parse, safeParse, parseAsync, safeParseAsync, min_length/max_length checks, chained checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Zod interpreter plugin enabling schema validation in the interpreter pipeline.
  * Supports both synchronous and asynchronous validation workflows.
  * Includes string validators with configurable length constraints.

* **Tests**
  * Added comprehensive test suite covering string parsing, validation, and chained validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->