### PR TITLE
feat: add error customization to zodInterpreter (#134)

### DIFF
--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -1,6 +1,27 @@
 import type { ASTNode, InterpreterFragment, StepEffect } from "@mvfm/core";
 import { z } from "zod";
-import type { CheckDescriptor } from "./types";
+import type { CheckDescriptor, ErrorConfig } from "./types";
+
+/**
+ * Convert an ErrorConfig (string or ASTNode) to a Zod-compatible error function.
+ * String errors become a function that returns the string for all issues.
+ * ASTNode errors would need interpreter context to evaluate — stored as descriptive string.
+ */
+function toZodError(error: ErrorConfig | undefined): ((iss: unknown) => string) | undefined {
+  if (error === undefined) return undefined;
+  if (typeof error === "string") return () => error;
+  // ASTNode error config — would need interpreter context to evaluate.
+  return () => `[dynamic error: ${JSON.stringify(error)}]`;
+}
+
+/**
+ * Build check-level error option for Zod check methods.
+ * Returns `{ error: fn }` if error is present, otherwise empty object.
+ */
+function checkErrorOpt(check: CheckDescriptor): { error?: (iss: unknown) => string } {
+  const fn = toZodError(check.error as ErrorConfig | undefined);
+  return fn ? { error: fn } : {};
+}
 
 /**
  * Apply check descriptors to a Zod string schema.
@@ -9,12 +30,13 @@ import type { CheckDescriptor } from "./types";
 function applyStringChecks(schema: z.ZodString, checks: CheckDescriptor[]): z.ZodString {
   let s = schema;
   for (const check of checks) {
+    const errOpt = checkErrorOpt(check);
     switch (check.kind) {
       case "min_length":
-        s = s.min(check.value as number);
+        s = s.min(check.value as number, errOpt);
         break;
       case "max_length":
-        s = s.max(check.value as number);
+        s = s.max(check.value as number, errOpt);
         break;
       // Additional string checks will be added by #137
       default:
@@ -32,12 +54,23 @@ function buildSchema(node: ASTNode): z.ZodType {
   switch (node.kind) {
     case "zod/string": {
       const checks = (node.checks as CheckDescriptor[]) ?? [];
-      return applyStringChecks(z.string(), checks);
+      const errorFn = toZodError(node.error as ErrorConfig | undefined);
+      const base = errorFn ? z.string({ error: errorFn }) : z.string();
+      return applyStringChecks(base, checks);
     }
     // Additional schema types will be added by colocated interpreter issues
     default:
       throw new Error(`Zod interpreter: unknown schema kind "${node.kind}"`);
   }
+}
+
+/**
+ * Build parse-level error option from the parseError field on validation nodes.
+ * In Zod v4, parse-level errors must be functions.
+ */
+function parseErrorOpt(node: ASTNode): { error?: (iss: unknown) => string } {
+  const fn = toZodError(node.parseError as ErrorConfig | undefined);
+  return fn ? { error: fn } : {};
 }
 
 /**
@@ -57,22 +90,22 @@ export const zodInterpreter: InterpreterFragment = {
       case "zod/parse": {
         const schema = buildSchema(node.schema as ASTNode);
         const input = yield { type: "recurse", child: node.input as ASTNode };
-        return schema.parse(input);
+        return schema.parse(input, parseErrorOpt(node));
       }
       case "zod/safe_parse": {
         const schema = buildSchema(node.schema as ASTNode);
         const input = yield { type: "recurse", child: node.input as ASTNode };
-        return schema.safeParse(input);
+        return schema.safeParse(input, parseErrorOpt(node));
       }
       case "zod/parse_async": {
         const schema = buildSchema(node.schema as ASTNode);
         const input = yield { type: "recurse", child: node.input as ASTNode };
-        return schema.parseAsync(input);
+        return schema.parseAsync(input, parseErrorOpt(node));
       }
       case "zod/safe_parse_async": {
         const schema = buildSchema(node.schema as ASTNode);
         const input = yield { type: "recurse", child: node.input as ASTNode };
-        return schema.safeParseAsync(input);
+        return schema.safeParseAsync(input, parseErrorOpt(node));
       }
       default:
         throw new Error(`Zod interpreter: unknown node kind "${node.kind}"`);

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -99,3 +99,61 @@ describe("zodInterpreter: parse operations (#133)", () => {
     expect(tooLong.success).toBe(false);
   });
 });
+
+describe("zodInterpreter: error customization (#134)", () => {
+  it("schema-level error appears in validation output", async () => {
+    const prog = app(($) => $.zod.string("Must be a string!").safeParse($.input.value));
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Must be a string!");
+  });
+
+  it("schema-level error via object form", async () => {
+    const prog = app(($) => $.zod.string({ error: "Bad type!" }).safeParse($.input.value));
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Bad type!");
+  });
+
+  it("check-level error on min()", async () => {
+    const prog = app(($) =>
+      $.zod.string().min(5, { error: "Too short!" }).safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: "hi" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Too short!");
+  });
+
+  it("check-level error on max()", async () => {
+    const prog = app(($) => $.zod.string().max(3, { error: "Too long!" }).safeParse($.input.value));
+    const result = (await run(prog, { value: "toolong" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Too long!");
+  });
+
+  it("per-parse error appears in validation output", async () => {
+    const prog = app(($) => $.zod.string().safeParse($.input.value, { error: "Parse failed!" }));
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Parse failed!");
+  });
+
+  it("schema-level error takes precedence over parse-level error", async () => {
+    const prog = app(($) =>
+      $.zod.string("Schema error").safeParse($.input.value, { error: "Parse error" }),
+    );
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    // In Zod v4, schema-level error is baked into the schema and takes precedence
+    expect(result.error.message).toContain("Schema error");
+  });
+
+  it("no error config uses Zod default messages", async () => {
+    const prog = app(($) => $.zod.string().safeParse($.input.value));
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    // Default Zod message, not custom
+    expect(result.error.message).not.toContain("Must be");
+    expect(result.error.message).toContain("invalid_type");
+  });
+});


### PR DESCRIPTION
Closes #134

## What this does

Adds ErrorConfig handling to the zodInterpreter at three levels: schema-level errors (passed to `z.string({ error })`), check-level errors (passed to `.min()/.max()` options), and per-parse errors (passed to `.parse()/.safeParse()` options). String error configs are converted to Zod v4 error functions via `toZodError()`. ASTNode error configs are stored as descriptive strings for now.

## Design alignment

- **ErrorConfig consistency**: Uses the same `ErrorConfig` type alias from #97 throughout the interpreter, matching the builder-side pattern.
- **Zod v4 API**: Zod v4 requires error functions (not strings) at the parse level — `toZodError()` handles this conversion.

## Validation performed

- `pnpm --filter @mvfm/plugin-zod run check` — biome lint + tsc clean
- `pnpm --filter @mvfm/plugin-zod test` — 55/55 tests pass (7 new error customization tests)
- Tests cover: schema-level string error, object-form error, check-level min/max errors, per-parse error, schema vs parse precedence, default Zod messages