### PR TITLE
feat: add wrapper type interpretation to zodInterpreter (#136)

### DIFF
--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -157,3 +157,81 @@ describe("zodInterpreter: error customization (#134)", () => {
     expect(result.error.message).toContain("invalid_type");
   });
 });
+
+describe("zodInterpreter: wrapper types (#136)", () => {
+  it("optional() allows undefined", async () => {
+    const prog = app(($) => $.zod.string().optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "hi" })) as any;
+    const invalid = (await run(prog, { value: 42 })) as any;
+    expect(undef.success).toBe(true);
+    expect(undef.data).toBeUndefined();
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+
+  it("nullable() allows null", async () => {
+    const prog = app(($) => $.zod.string().nullable().safeParse($.input.value));
+    const nul = (await run(prog, { value: null })) as any;
+    const valid = (await run(prog, { value: "hi" })) as any;
+    expect(nul.success).toBe(true);
+    expect(nul.data).toBeNull();
+    expect(valid.success).toBe(true);
+  });
+
+  it("nullish() allows null and undefined", async () => {
+    const prog = app(($) => $.zod.string().nullish().safeParse($.input.value));
+    const nul = (await run(prog, { value: null })) as any;
+    const undef = (await run(prog, { value: undefined })) as any;
+    expect(nul.success).toBe(true);
+    expect(undef.success).toBe(true);
+  });
+
+  it("default() provides fallback for undefined", async () => {
+    const prog = app(($) => $.zod.string().default("fallback").parse($.input.value));
+    expect(await run(prog, { value: undefined })).toBe("fallback");
+    expect(await run(prog, { value: "given" })).toBe("given");
+  });
+
+  it("catch() provides fallback on validation error", async () => {
+    const prog = app(($) => $.zod.string().catch("caught").parse($.input.value));
+    expect(await run(prog, { value: 42 })).toBe("caught");
+    expect(await run(prog, { value: "ok" })).toBe("ok");
+  });
+
+  it("readonly() passes through values", async () => {
+    const prog = app(($) => $.zod.string().readonly().parse($.input.value));
+    expect(await run(prog, { value: "hi" })).toBe("hi");
+  });
+
+  it("brand() passes through values", async () => {
+    const prog = app(($) => $.zod.string().brand("Email").parse($.input.value));
+    expect(await run(prog, { value: "test@example.com" })).toBe("test@example.com");
+  });
+
+  it("composed wrappers: optional().nullable()", async () => {
+    const prog = app(($) => $.zod.string().optional().nullable().safeParse($.input.value));
+    const nul = (await run(prog, { value: null })) as any;
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "hi" })) as any;
+    expect(nul.success).toBe(true);
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+  });
+
+  it("wrapper with checks: optional string with min", async () => {
+    const prog = app(($) => $.zod.string().min(3).optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    const short = (await run(prog, { value: "hi" })) as any;
+    const valid = (await run(prog, { value: "hello" })) as any;
+    expect(undef.success).toBe(true);
+    expect(short.success).toBe(false);
+    expect(valid.success).toBe(true);
+  });
+
+  it("prefault() provides pre-parse default", async () => {
+    const prog = app(($) => $.zod.string().prefault("pre").parse($.input.value));
+    expect(await run(prog, { value: undefined })).toBe("pre");
+    expect(await run(prog, { value: "given" })).toBe("given");
+  });
+});


### PR DESCRIPTION
Closes #136

## What this does

Adds interpretation for all 9 wrapper node kinds to the zodInterpreter. Refactors `buildSchema` into a generator function (`buildSchemaGen`) so value-carrying wrappers (default, prefault, catch) can yield recurse effects to evaluate their value AST nodes at runtime. Simple wrappers (optional, nullable, etc.) are handled synchronously within the generator.

## Design alignment

- **Generator composition**: Uses `yield*` to delegate from `*visit` to `buildSchemaGen`, maintaining the standard InterpreterFragment generator contract.
- **Value evaluation via recurse**: Default/prefault/catch values are AST nodes (from `ctx.lift()`) that get evaluated through the interpreter's recurse mechanism, not hardcoded.

## Validation performed

- `pnpm --filter @mvfm/plugin-zod run check` — biome lint + tsc clean
- `pnpm --filter @mvfm/plugin-zod test` — 65/65 tests pass (10 new wrapper interpreter tests)
- Tests cover: optional/nullable/nullish/default/catch/readonly/brand/prefault, composed wrappers, wrappers with checks