### PR TITLE
feat: add refinement interpretation and deduplicate injectLambdaParam

### DIFF
--- a/packages/core/etc/core.api.json
+++ b/packages/core/etc/core.api.json
@@ -2647,6 +2647,83 @@
           "name": "inferType"
         },
         {
+          "kind": "Function",
+          "canonicalReference": "@mvfm/core!injectLambdaParam:function(1)",
+          "docComment": "/**\n * Walk an AST subtree and inject a runtime value into matching `core/lambda_param` nodes.\n *\n * This is the standard mechanism for evaluating lambda expressions at runtime: clone the lambda body, inject the argument value into the param nodes, then recurse through the interpreter to evaluate the body.\n *\n * @param node - AST subtree to walk (typically a cloned lambda body)\n *\n * @param name - The param name to match against `core/lambda_param` nodes\n *\n * @param value - The runtime value to inject\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function injectLambdaParam(node: "
+            },
+            {
+              "kind": "Content",
+              "text": "any"
+            },
+            {
+              "kind": "Content",
+              "text": ", name: "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
+            },
+            {
+              "kind": "Content",
+              "text": ", value: "
+            },
+            {
+              "kind": "Content",
+              "text": "unknown"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "void"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "dist/core.d.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 7,
+            "endIndex": 8
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "node",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "name",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "value",
+              "parameterTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 6
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "injectLambdaParam"
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "@mvfm/core!Interpreter:type",
           "docComment": "/**\n * An interpreter is a function that takes a {@link Program} and returns a runner with an async `run` method.\n */\n",

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -165,6 +165,9 @@ export type InferSchema<S> = S extends SchemaTag ? TagToType<S> : S extends {
 export function inferType(node: ASTNode, impls: TraitImpl[], schema?: Record<string, unknown>): string | null;
 
 // @public
+export function injectLambdaParam(node: any, name: string, value: unknown): void;
+
+// @public
 export type Interpreter = (program: Program) => {
     run: (input: Record<string, unknown>) => Promise<unknown>;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,15 @@ export type {
   TypeclassMapping,
   TypeclassSlot,
 } from "./core";
-export { adaptLegacy, composeInterpreters, foldAST, mvfm, runAST, Stepper } from "./core";
+export {
+  adaptLegacy,
+  composeInterpreters,
+  foldAST,
+  injectLambdaParam,
+  mvfm,
+  runAST,
+  Stepper,
+} from "./core";
 export { coreInterpreter } from "./interpreters/core";
 export type { BooleanMethods } from "./plugins/boolean";
 export { boolean } from "./plugins/boolean";

--- a/packages/core/src/plugins/fiber/handler.ts
+++ b/packages/core/src/plugins/fiber/handler.ts
@@ -1,6 +1,5 @@
 import type { ASTNode, InterpreterFragment, StepEffect, StepHandler } from "../../core";
-import { runAST } from "../../core";
-import { injectLambdaParam } from "./interpreter";
+import { injectLambdaParam, runAST } from "../../core";
 
 /**
  * Effect handler for fiber/ effects (concurrency).

--- a/packages/core/src/plugins/fiber/interpreter.ts
+++ b/packages/core/src/plugins/fiber/interpreter.ts
@@ -1,24 +1,5 @@
 import type { ASTNode, InterpreterFragment, StepEffect } from "../../core";
-
-/**
- * Walk an AST subtree and inject a value into matching lambda_param nodes.
- * This is how the fiber interpreter passes collection items to the par_map body.
- */
-export function injectLambdaParam(node: any, name: string, value: unknown): void {
-  if (node === null || node === undefined || typeof node !== "object") return;
-  if (Array.isArray(node)) {
-    for (const item of node) injectLambdaParam(item, name, value);
-    return;
-  }
-  if (node.kind === "core/lambda_param" && node.name === name) {
-    node.__value = value;
-  }
-  for (const v of Object.values(node)) {
-    if (typeof v === "object" && v !== null) {
-      injectLambdaParam(v, name, value);
-    }
-  }
-}
+import { injectLambdaParam } from "../../core";
 
 /** Interpreter fragment for `fiber/` node kinds. */
 export const fiberInterpreter: InterpreterFragment = {

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -1,4 +1,4 @@
-import { composeInterpreters, coreInterpreter, mvfm } from "@mvfm/core";
+import { composeInterpreters, coreInterpreter, mvfm, str, strInterpreter } from "@mvfm/core";
 import { describe, expect, it } from "vitest";
 import { zod, zodInterpreter } from "../src/index";
 
@@ -17,11 +17,12 @@ function injectInput(node: any, input: Record<string, unknown>): any {
 /** Build AST from DSL, inject input, compose interpreters, evaluate. */
 async function run(prog: { ast: any }, input: Record<string, unknown> = {}) {
   const ast = injectInput(prog.ast, input);
-  const interp = composeInterpreters([coreInterpreter, zodInterpreter]);
+  const interp = composeInterpreters([coreInterpreter, strInterpreter, zodInterpreter]);
   return await interp(ast.result);
 }
 
 const app = mvfm(zod);
+const appWithStr = mvfm(zod, str);
 
 describe("zodInterpreter: parse operations (#133)", () => {
   it("parse() validates valid string input", async () => {
@@ -233,5 +234,123 @@ describe("zodInterpreter: wrapper types (#136)", () => {
     const prog = app(($) => $.zod.string().prefault("pre").parse($.input.value));
     expect(await run(prog, { value: undefined })).toBe("pre");
     expect(await run(prog, { value: "given" })).toBe("given");
+  });
+});
+
+describe("zodInterpreter: refinements (#135)", () => {
+  it("refine() passes when predicate returns true", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .refine((val) => $.startsWith(val, "hello"))
+        .parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello world" })).toBe("hello world");
+  });
+
+  it("refine() throws when predicate returns false", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .refine((val) => $.startsWith(val, "hello"))
+        .parse($.input.value),
+    );
+    await expect(run(prog, { value: "goodbye" })).rejects.toThrow("Refinement failed");
+  });
+
+  it("refine() uses custom error message", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .refine((val) => $.startsWith(val, "hello"), { error: "Must start with hello" })
+        .parse($.input.value),
+    );
+    await expect(run(prog, { value: "goodbye" })).rejects.toThrow("Must start with hello");
+  });
+
+  it("check() passes when predicate returns true", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .check((val) => $.includes(val, "@"))
+        .parse($.input.value),
+    );
+    expect(await run(prog, { value: "user@example.com" })).toBe("user@example.com");
+  });
+
+  it("check() throws when predicate returns false", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .check((val) => $.includes(val, "@"), { error: "Must contain @" })
+        .parse($.input.value),
+    );
+    await expect(run(prog, { value: "no-at-sign" })).rejects.toThrow("Must contain @");
+  });
+
+  it("overwrite() transforms the validated value", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .overwrite((val) => $.upper(val))
+        .parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello" })).toBe("HELLO");
+  });
+
+  it("chained refinements execute in order", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .overwrite((val) => $.upper(val))
+        .refine((val) => $.startsWith(val, "HELLO"))
+        .parse($.input.value),
+    );
+    // overwrite runs first → "HELLO", then refine checks startsWith("HELLO") → passes
+    expect(await run(prog, { value: "hello" })).toBe("HELLO");
+  });
+
+  it("safeParse catches refinement failure", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .refine((val) => $.startsWith(val, "x"), { error: "Must start with x" })
+        .safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: "hello" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toBe("Must start with x");
+  });
+
+  it("safeParse returns refined value on success", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .overwrite((val) => $.trim(val))
+        .safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: "  hello  " })) as any;
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("hello");
+  });
+
+  it("refinements run after Zod checks", async () => {
+    // min(3) check runs first via Zod, then refine predicate runs
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .min(3)
+        .refine((val) => $.endsWith(val, "!"))
+        .safeParse($.input.value),
+    );
+    // Too short — Zod check fails before refinement runs
+    const short = (await run(prog, { value: "hi" })) as any;
+    expect(short.success).toBe(false);
+    // Long enough but doesn't end with !
+    const noExcl = (await run(prog, { value: "hello" })) as any;
+    expect(noExcl.success).toBe(false);
+    // Passes both
+    const valid = (await run(prog, { value: "hello!" })) as any;
+    expect(valid.success).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #135

## What this does

Adds refinement interpretation to the zodInterpreter — `refine`, `check`, `overwrite`, and `superRefine` DSL refinements are now evaluated at validation time. Also deduplicates `injectLambdaParam` by extracting a canonical version into `@mvfm/core` and updating all consumers (fiber interpreter, fiber handler, error interpreter).

Refinements are applied after Zod validates the base schema: the interpreter clones each refinement's lambda body, injects the validated value via `injectLambdaParam`, and evaluates through the standard generator pipeline. This means refinement predicates can use any DSL operations from any loaded plugin.

## Design alignment

- **Plugin interpreter colocation**: Interpreter coverage is colocated with the refinement feature (VISION.md principle)
- **Generator-based interpretation**: Uses `yield { type: "recurse", child }` effects, matching the standard interpreter pattern
- **No duplication**: `injectLambdaParam` is now a single canonical export from core, used by fiber, error, and zod interpreters

## Validation performed

- `pnpm run build` — all packages compile cleanly
- `pnpm run check` — biome + tsc + api-extractor pass
- `pnpm test` — all tests pass across all packages (319 core + 75 plugin-zod + all other plugins)
- 10 new refinement interpreter tests covering: refine pass/fail, check pass/fail, overwrite transform, chained refinements, safeParse error handling, and refinements-after-checks ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)