### PR TITLE
feat(plugin-zod): number schema, validations, and interpreter

### DIFF
--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -1,9 +1,11 @@
 import type { PluginDefinition } from "@mvfm/core";
+import { ZodNumberBuilder } from "./number";
 import { ZodStringBuilder } from "./string";
 
 // Re-export types, builders, and interpreter for consumers
 export { ZodSchemaBuilder, ZodWrappedBuilder } from "./base";
 export { zodInterpreter } from "./interpreter";
+export { ZodNumberBuilder } from "./number";
 export { ZodStringBuilder } from "./string";
 export type {
   CheckDescriptor,
@@ -37,14 +39,48 @@ export interface ZodNamespace {
   /** Create a string schema builder. */
   string(errorOrOpts?: string | { error?: string }): ZodStringBuilder;
 
+  /** Create a number schema builder. */
+  number(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create an integer schema builder (safe integer range). */
+  int(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create an int32 schema builder. */
+  int32(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create an int64 schema builder. */
+  int64(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create a uint32 schema builder. */
+  uint32(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create a uint64 schema builder. */
+  uint64(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create a float32 schema builder. */
+  float32(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /** Create a float64 schema builder. */
+  float64(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
+  /**
+   * Create a NaN schema builder. Produces `zod/nan` AST node.
+   * Validates that the input is specifically NaN.
+   */
+  nan(errorOrOpts?: string | { error?: string }): ZodNumberBuilder;
+
   // ---- Stubs for future schema types ----
-  // Each issue (#102-#120) adds its factory method here.
-  // number(errorOrOpts?): ZodNumberBuilder;
+  // Each issue (#103-#120) adds its factory method here.
   // bigint(errorOrOpts?): ZodBigIntBuilder;
   // boolean(errorOrOpts?): ZodBooleanBuilder;
   // object(shape): ZodObjectBuilder;
   // array(element): ZodArrayBuilder;
   // ... etc.
+}
+
+/** Parse error config from the standard `errorOrOpts` param. */
+function parseError(errorOrOpts?: string | { error?: string }): string | undefined {
+  return typeof errorOrOpts === "string" ? errorOrOpts : errorOrOpts?.error;
 }
 
 /**
@@ -68,6 +104,8 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
 
     // Schema types — each issue adds its kinds here
     "zod/string", // #100
+    "zod/number", // #102
+    "zod/nan", // #102
 
     // Wrappers (#99)
     "zod/optional",
@@ -85,8 +123,38 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     return {
       zod: {
         string(errorOrOpts?: string | { error?: string }): ZodStringBuilder {
-          const error = typeof errorOrOpts === "string" ? errorOrOpts : errorOrOpts?.error;
-          return new ZodStringBuilder(ctx, [], [], error);
+          return new ZodStringBuilder(ctx, [], [], parseError(errorOrOpts));
+        },
+        number(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts));
+        },
+        int(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), { variant: "int" });
+        },
+        int32(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), { variant: "int32" });
+        },
+        int64(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), { variant: "int64" });
+        },
+        uint32(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), { variant: "uint32" });
+        },
+        uint64(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), { variant: "uint64" });
+        },
+        float32(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), {
+            variant: "float32",
+          });
+        },
+        float64(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), {
+            variant: "float64",
+          });
+        },
+        nan(errorOrOpts?: string | { error?: string }): ZodNumberBuilder {
+          return new ZodNumberBuilder(ctx, [], [], parseError(errorOrOpts), {}, "zod/nan");
         },
       },
     };

--- a/packages/plugin-zod/src/number.ts
+++ b/packages/plugin-zod/src/number.ts
@@ -1,0 +1,127 @@
+import type { ASTNode, PluginContext } from "@mvfm/core";
+import { ZodSchemaBuilder } from "./base";
+import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+
+/**
+ * Builder for Zod number schemas.
+ *
+ * Provides number-specific validations (gt, gte, lt, lte, positive, negative,
+ * multipleOf) on top of the common base methods.
+ */
+export class ZodNumberBuilder extends ZodSchemaBuilder<number> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+    kind: "zod/number" | "zod/nan" = "zod/number",
+  ) {
+    super(ctx, kind, checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodNumberBuilder {
+    return new ZodNumberBuilder(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+      this._kind as "zod/number" | "zod/nan",
+    );
+  }
+
+  // ---- Comparison checks ----
+
+  /** Greater than. Produces `gt` check descriptor. */
+  gt(value: number, opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("gt", { value }, opts);
+  }
+
+  /** Greater than or equal (alias: min). Produces `gte` check descriptor. */
+  gte(value: number, opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("gte", { value }, opts);
+  }
+
+  /** Alias for gte(). */
+  min(value: number, opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this.gte(value, opts);
+  }
+
+  /** Less than. Produces `lt` check descriptor. */
+  lt(value: number, opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("lt", { value }, opts);
+  }
+
+  /** Less than or equal (alias: max). Produces `lte` check descriptor. */
+  lte(value: number, opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("lte", { value }, opts);
+  }
+
+  /** Alias for lte(). */
+  max(value: number, opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this.lte(value, opts);
+  }
+
+  // ---- Sign checks ----
+
+  /** Must be > 0. Produces `positive` check descriptor. */
+  positive(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("positive", {}, opts);
+  }
+
+  /** Must be >= 0. Produces `nonnegative` check descriptor. */
+  nonnegative(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("nonnegative", {}, opts);
+  }
+
+  /** Must be < 0. Produces `negative` check descriptor. */
+  negative(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("negative", {}, opts);
+  }
+
+  /** Must be <= 0. Produces `nonpositive` check descriptor. */
+  nonpositive(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("nonpositive", {}, opts);
+  }
+
+  // ---- Divisibility ----
+
+  /** Must be a multiple of step. Produces `multiple_of` check descriptor. */
+  multipleOf(
+    step: number,
+    opts?: { error?: string; abort?: boolean; when?: ASTNode },
+  ): ZodNumberBuilder {
+    return this._addCheck("multiple_of", { value: step }, opts);
+  }
+
+  /** Alias for multipleOf(). */
+  step(
+    value: number,
+    opts?: { error?: string; abort?: boolean; when?: ASTNode },
+  ): ZodNumberBuilder {
+    return this.multipleOf(value, opts);
+  }
+
+  // ---- Integer/finite/safe checks ----
+
+  /** Must be an integer. Produces `int` check descriptor. */
+  int(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("int", {}, opts);
+  }
+
+  /** Must be finite. Produces `finite` check descriptor. */
+  finite(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("finite", {}, opts);
+  }
+
+  /** Must be a safe integer. Produces `safe` check descriptor. */
+  safe(opts?: { error?: string; abort?: boolean; when?: ASTNode }): ZodNumberBuilder {
+    return this._addCheck("safe", {}, opts);
+  }
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -1,6 +1,6 @@
 import { mvfm } from "@mvfm/core";
 import { describe, expect, it } from "vitest";
-import { ZodStringBuilder, ZodWrappedBuilder, zod } from "../src/index";
+import { ZodNumberBuilder, ZodStringBuilder, ZodWrappedBuilder, zod } from "../src/index";
 
 // Helper: strip __id from AST for snapshot-stable assertions
 function strip(ast: unknown): unknown {
@@ -550,5 +550,134 @@ describe("zod string: full validations (#100)", () => {
     );
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.checks[0].error).toBe("Must start with x");
+  });
+});
+
+describe("number schema (#102)", () => {
+  it("$.zod.number() returns a ZodNumberBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.number();
+      expect(builder).toBeInstanceOf(ZodNumberBuilder);
+      return builder.parse(42);
+    });
+  });
+
+  it("$.zod.number() produces zod/number AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.number().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/number");
+    expect(ast.result.schema.checks).toEqual([]);
+  });
+
+  it("$.zod.number() accepts error param", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.number("Not a number!").parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.error).toBe("Not a number!");
+  });
+
+  it("gt() adds gt check", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.number().gt(5).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.checks).toHaveLength(1);
+    expect(ast.result.schema.checks[0]).toMatchObject({ kind: "gt", value: 5 });
+  });
+
+  it("gte() and min() are aliases", () => {
+    const app = mvfm(zod);
+    const prog1 = app(($) => $.zod.number().gte(10).parse($.input));
+    const prog2 = app(($) => $.zod.number().min(10).parse($.input));
+    const ast1 = strip(prog1.ast) as any;
+    const ast2 = strip(prog2.ast) as any;
+    expect(ast1.result.schema.checks[0]).toMatchObject({ kind: "gte", value: 10 });
+    expect(ast2.result.schema.checks[0]).toMatchObject({ kind: "gte", value: 10 });
+  });
+
+  it("lt() adds lt check", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.number().lt(100).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.checks[0]).toMatchObject({ kind: "lt", value: 100 });
+  });
+
+  it("lte() and max() are aliases", () => {
+    const app = mvfm(zod);
+    const prog1 = app(($) => $.zod.number().lte(50).parse($.input));
+    const prog2 = app(($) => $.zod.number().max(50).parse($.input));
+    const ast1 = strip(prog1.ast) as any;
+    const ast2 = strip(prog2.ast) as any;
+    expect(ast1.result.schema.checks[0]).toMatchObject({ kind: "lte", value: 50 });
+    expect(ast2.result.schema.checks[0]).toMatchObject({ kind: "lte", value: 50 });
+  });
+
+  it("positive/nonnegative/negative/nonpositive add sign checks", () => {
+    const app = mvfm(zod);
+    const prog = app(($) =>
+      $.zod.number().positive().nonnegative().negative().nonpositive().parse($.input),
+    );
+    const ast = strip(prog.ast) as any;
+    const kinds = ast.result.schema.checks.map((c: any) => c.kind);
+    expect(kinds).toEqual(["positive", "nonnegative", "negative", "nonpositive"]);
+  });
+
+  it("multipleOf() and step() are aliases", () => {
+    const app = mvfm(zod);
+    const prog1 = app(($) => $.zod.number().multipleOf(3).parse($.input));
+    const prog2 = app(($) => $.zod.number().step(3).parse($.input));
+    const ast1 = strip(prog1.ast) as any;
+    const ast2 = strip(prog2.ast) as any;
+    expect(ast1.result.schema.checks[0]).toMatchObject({ kind: "multiple_of", value: 3 });
+    expect(ast2.result.schema.checks[0]).toMatchObject({ kind: "multiple_of", value: 3 });
+  });
+
+  it("int/finite/safe checks produce correct descriptors", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.number().int().finite().safe().parse($.input));
+    const ast = strip(prog.ast) as any;
+    const kinds = ast.result.schema.checks.map((c: any) => c.kind);
+    expect(kinds).toEqual(["int", "finite", "safe"]);
+  });
+
+  it("integer variants set variant field", () => {
+    const app = mvfm(zod);
+    for (const v of ["int", "int32", "int64", "uint32", "uint64", "float32", "float64"] as const) {
+      const prog = app(($) => $.zod[v]().parse($.input));
+      const ast = strip(prog.ast) as any;
+      expect(ast.result.schema.kind).toBe("zod/number");
+      expect(ast.result.schema.variant).toBe(v);
+    }
+  });
+
+  it("$.zod.nan() produces zod/nan AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.nan().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/nan");
+  });
+
+  it("chained number checks accumulate immutably", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      const n1 = $.zod.number();
+      const n2 = n1.gt(0);
+      const n3 = n2.lt(100);
+      expect(n1).not.toBe(n2);
+      expect(n2).not.toBe(n3);
+      return n3.parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.checks).toHaveLength(2);
+    expect(ast.result.schema.checks[0]).toMatchObject({ kind: "gt", value: 0 });
+    expect(ast.result.schema.checks[1]).toMatchObject({ kind: "lt", value: 100 });
+  });
+
+  it("check-level error options work on number checks", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.number().gt(0, { error: "Must be positive!" }).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.checks[0].error).toBe("Must be positive!");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -237,6 +237,158 @@ describe("zodInterpreter: wrapper types (#136)", () => {
   });
 });
 
+describe("zodInterpreter: number schema (#139)", () => {
+  it("number parse validates valid number", async () => {
+    const prog = app(($) => $.zod.number().parse($.input.value));
+    expect(await run(prog, { value: 42 })).toBe(42);
+  });
+
+  it("number parse rejects non-number", async () => {
+    const prog = app(($) => $.zod.number().parse($.input.value));
+    await expect(run(prog, { value: "hello" })).rejects.toThrow();
+  });
+
+  it("gt check rejects values not greater than", async () => {
+    const prog = app(($) => $.zod.number().gt(5).safeParse($.input.value));
+    const fail = (await run(prog, { value: 5 })) as any;
+    const pass = (await run(prog, { value: 6 })) as any;
+    expect(fail.success).toBe(false);
+    expect(pass.success).toBe(true);
+  });
+
+  it("gte check accepts equal values", async () => {
+    const prog = app(($) => $.zod.number().gte(5).safeParse($.input.value));
+    const pass = (await run(prog, { value: 5 })) as any;
+    const fail = (await run(prog, { value: 4 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("lt check rejects values not less than", async () => {
+    const prog = app(($) => $.zod.number().lt(10).safeParse($.input.value));
+    const fail = (await run(prog, { value: 10 })) as any;
+    const pass = (await run(prog, { value: 9 })) as any;
+    expect(fail.success).toBe(false);
+    expect(pass.success).toBe(true);
+  });
+
+  it("lte check accepts equal values", async () => {
+    const prog = app(($) => $.zod.number().lte(10).safeParse($.input.value));
+    const pass = (await run(prog, { value: 10 })) as any;
+    const fail = (await run(prog, { value: 11 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("positive rejects zero and negative", async () => {
+    const prog = app(($) => $.zod.number().positive().safeParse($.input.value));
+    const zero = (await run(prog, { value: 0 })) as any;
+    const neg = (await run(prog, { value: -1 })) as any;
+    const pos = (await run(prog, { value: 1 })) as any;
+    expect(zero.success).toBe(false);
+    expect(neg.success).toBe(false);
+    expect(pos.success).toBe(true);
+  });
+
+  it("nonnegative accepts zero", async () => {
+    const prog = app(($) => $.zod.number().nonnegative().safeParse($.input.value));
+    const zero = (await run(prog, { value: 0 })) as any;
+    const neg = (await run(prog, { value: -1 })) as any;
+    expect(zero.success).toBe(true);
+    expect(neg.success).toBe(false);
+  });
+
+  it("negative rejects zero and positive", async () => {
+    const prog = app(($) => $.zod.number().negative().safeParse($.input.value));
+    const neg = (await run(prog, { value: -1 })) as any;
+    const zero = (await run(prog, { value: 0 })) as any;
+    expect(neg.success).toBe(true);
+    expect(zero.success).toBe(false);
+  });
+
+  it("nonpositive accepts zero", async () => {
+    const prog = app(($) => $.zod.number().nonpositive().safeParse($.input.value));
+    const zero = (await run(prog, { value: 0 })) as any;
+    const pos = (await run(prog, { value: 1 })) as any;
+    expect(zero.success).toBe(true);
+    expect(pos.success).toBe(false);
+  });
+
+  it("multipleOf checks divisibility", async () => {
+    const prog = app(($) => $.zod.number().multipleOf(3).safeParse($.input.value));
+    const pass = (await run(prog, { value: 9 })) as any;
+    const fail = (await run(prog, { value: 10 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("int variant rejects non-integers", async () => {
+    const prog = app(($) => $.zod.int().safeParse($.input.value));
+    const pass = (await run(prog, { value: 42 })) as any;
+    const fail = (await run(prog, { value: 3.14 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("int32 variant rejects out-of-range", async () => {
+    const prog = app(($) => $.zod.int32().safeParse($.input.value));
+    const pass = (await run(prog, { value: 100 })) as any;
+    const fail = (await run(prog, { value: 2147483648 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("uint32 variant rejects negatives", async () => {
+    const prog = app(($) => $.zod.uint32().safeParse($.input.value));
+    const pass = (await run(prog, { value: 0 })) as any;
+    const fail = (await run(prog, { value: -1 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("float64 variant rejects Infinity", async () => {
+    const prog = app(($) => $.zod.float64().safeParse($.input.value));
+    const pass = (await run(prog, { value: 3.14 })) as any;
+    const fail = (await run(prog, { value: Number.POSITIVE_INFINITY })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("nan() validates NaN specifically", async () => {
+    const prog = app(($) => $.zod.nan().safeParse($.input.value));
+    const pass = (await run(prog, { value: Number.NaN })) as any;
+    const fail = (await run(prog, { value: 42 })) as any;
+    expect(pass.success).toBe(true);
+    expect(fail.success).toBe(false);
+  });
+
+  it("number check-level error appears in output", async () => {
+    const prog = app(($) =>
+      $.zod.number().gt(0, { error: "Must be positive!" }).safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: -5 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Must be positive!");
+  });
+
+  it("number schema-level error appears in output", async () => {
+    const prog = app(($) => $.zod.number("Expected a number").safeParse($.input.value));
+    const result = (await run(prog, { value: "hello" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Expected a number");
+  });
+
+  it("number with optional wrapper", async () => {
+    const prog = app(($) => $.zod.number().optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: 42 })) as any;
+    const invalid = (await run(prog, { value: "hello" })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+});
+
 describe("zodInterpreter: refinements (#135)", () => {
   it("refine() passes when predicate returns true", async () => {
     const prog = appWithStr(($) =>


### PR DESCRIPTION
Closes #102
Closes #139

## What this does
Adds `ZodNumberBuilder` with all number-specific validations (gt, gte/min, lt, lte/max, positive, nonnegative, negative, nonpositive, multipleOf/step, int, finite, safe), variant constructors (int, int32, int64, uint32, uint64, float32, float64), and `z.nan()` support. Adds interpreter support for `zod/number` and `zod/nan` node kinds with variant-based constraint expansion.

## Design alignment
- **Plugin contract**: `number.ts` extends `ZodSchemaBuilder<number>` per the base class pattern. Node kinds `zod/number` and `zod/nan` registered in `nodeKinds`.
- **AST determinism**: All checks serialize as `CheckDescriptor` objects. Variant field stored in `extra`. NaN uses separate `zod/nan` kind.
- **Immutable chaining**: Each method returns new builder instance via `_clone()`.

## Validation performed
- `pnpm run -r build` — all packages compile clean
- `pnpm run check` — biome + tsc pass
- `pnpm run test` — 108 plugin-zod tests (43 new), 319 core tests, all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Zod plugin with comprehensive numeric validation support, including multiple numeric type variants and specialized validation constraints for numeric fields such as comparisons, sign checks, divisibility, and boundary handling.
  * Enhanced the plugin's public API with factory methods for creating numeric schema builders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->