### PR TITLE
feat(plugin-zod): enum + native enum schemas + interpreter (#108, #145)

### DIFF
--- a/packages/plugin-zod/src/enum.ts
+++ b/packages/plugin-zod/src/enum.ts
@@ -1,0 +1,160 @@
+import type { ASTNode, PluginContext, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import { toZodError } from "./interpreter-utils";
+import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+
+/**
+ * Builder for Zod enum schemas.
+ *
+ * Validates that input is one of a fixed set of string values.
+ * Supports `.extract()` and `.exclude()` for deriving sub-enums.
+ *
+ * @typeParam T - Union of the allowed string values
+ */
+export class ZodEnumBuilder<T extends string> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/enum", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodEnumBuilder<T> {
+    return new ZodEnumBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+
+  /** Create a new enum with only the specified values. */
+  extract<U extends T>(values: U[]): ZodEnumBuilder<U> {
+    return new ZodEnumBuilder<U>(this._ctx, [], [], this._error, {
+      ...this._extra,
+      values,
+    });
+  }
+
+  /** Create a new enum without the specified values. */
+  exclude<U extends T>(values: U[]): ZodEnumBuilder<Exclude<T, U>> {
+    const current = (this._extra.values as T[]) ?? [];
+    const remaining = current.filter((v) => !values.includes(v as U));
+    return new ZodEnumBuilder<Exclude<T, U>>(this._ctx, [], [], this._error, {
+      ...this._extra,
+      values: remaining,
+    });
+  }
+}
+
+/**
+ * Builder for Zod native enum schemas.
+ *
+ * Validates that input is one of the values from a TypeScript enum
+ * or object literal with string/number values.
+ *
+ * @typeParam T - The output type (union of enum values)
+ */
+export class ZodNativeEnumBuilder<T> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/native_enum", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodNativeEnumBuilder<T> {
+    return new ZodNativeEnumBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Node kinds contributed by enum schemas. */
+export const enumNodeKinds: string[] = ["zod/enum", "zod/native_enum"];
+
+/**
+ * Namespace fragment for enum schema factories.
+ */
+export interface ZodEnumNamespace {
+  /**
+   * Create an enum schema from string values.
+   * Validates that input matches one of the provided strings.
+   */
+  enum<T extends string>(values: T[], errorOrOpts?: string | { error?: string }): ZodEnumBuilder<T>;
+
+  /**
+   * Create a native enum schema from a TypeScript enum or object literal.
+   * Validates that input matches one of the enum's values.
+   */
+  nativeEnum<T extends Record<string, string | number>>(
+    enumObj: T,
+    errorOrOpts?: string | { error?: string },
+  ): ZodNativeEnumBuilder<T[keyof T]>;
+}
+
+/** Build the enum namespace factory methods. */
+export function enumNamespace(
+  ctx: PluginContext,
+  parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodEnumNamespace {
+  return {
+    enum<T extends string>(
+      values: T[],
+      errorOrOpts?: string | { error?: string },
+    ): ZodEnumBuilder<T> {
+      return new ZodEnumBuilder<T>(ctx, [], [], parseError(errorOrOpts), { values });
+    },
+
+    nativeEnum<T extends Record<string, string | number>>(
+      enumObj: T,
+      errorOrOpts?: string | { error?: string },
+    ): ZodNativeEnumBuilder<T[keyof T]> {
+      return new ZodNativeEnumBuilder<T[keyof T]>(ctx, [], [], parseError(errorOrOpts), {
+        entries: enumObj,
+      });
+    },
+  };
+}
+
+/** Interpreter handlers for enum schema nodes. */
+export const enumInterpreter: SchemaInterpreterMap = {
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/enum": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+    const values = node.values as [string, ...string[]];
+    const errorFn = toZodError(node.error as ErrorConfig | undefined);
+    const errOpt = errorFn ? { error: errorFn } : {};
+    return z.enum(values, errOpt);
+  },
+
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/native_enum": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+    const entries = node.entries as Record<string, string | number>;
+    const errorFn = toZodError(node.error as ErrorConfig | undefined);
+    const errOpt = errorFn ? { error: errorFn } : {};
+    return z.nativeEnum(entries, errOpt);
+  },
+};

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -3,6 +3,8 @@ import type { ZodBigIntNamespace } from "./bigint";
 import { bigintNamespace, bigintNodeKinds } from "./bigint";
 import type { ZodDateNamespace } from "./date";
 import { dateNamespace, dateNodeKinds } from "./date";
+import type { ZodEnumNamespace } from "./enum";
+import { enumNamespace, enumNodeKinds } from "./enum";
 import type { ZodLiteralNamespace } from "./literal";
 import { literalNamespace, literalNodeKinds } from "./literal";
 import type { ZodNumberNamespace } from "./number";
@@ -16,6 +18,7 @@ import { stringNamespace, stringNodeKinds } from "./string";
 export { ZodSchemaBuilder, ZodWrappedBuilder } from "./base";
 export { ZodBigIntBuilder } from "./bigint";
 export { ZodDateBuilder } from "./date";
+export { ZodEnumBuilder, ZodNativeEnumBuilder } from "./enum";
 export { zodInterpreter } from "./interpreter";
 export type { SchemaInterpreterMap } from "./interpreter-utils";
 export { ZodLiteralBuilder } from "./literal";
@@ -45,6 +48,7 @@ export interface ZodNamespace
   extends ZodStringNamespace,
     ZodBigIntNamespace,
     ZodDateNamespace,
+    ZodEnumNamespace,
     ZodLiteralNamespace,
     ZodNumberNamespace,
     ZodPrimitivesNamespace {
@@ -90,6 +94,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...stringNodeKinds,
     ...bigintNodeKinds,
     ...dateNodeKinds,
+    ...enumNodeKinds,
     ...literalNodeKinds,
     ...numberNodeKinds,
     ...primitivesNodeKinds,
@@ -102,6 +107,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...stringNamespace(ctx, parseError),
         ...bigintNamespace(ctx, parseError),
         ...dateNamespace(ctx, parseError),
+        ...enumNamespace(ctx, parseError),
         ...literalNamespace(ctx),
         ...numberNamespace(ctx, parseError),
         ...primitivesNamespace(ctx, parseError),

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -3,6 +3,7 @@ import { injectLambdaParam } from "@mvfm/core";
 import type { z } from "zod";
 import { bigintInterpreter } from "./bigint";
 import { dateInterpreter } from "./date";
+import { enumInterpreter } from "./enum";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { toZodError } from "./interpreter-utils";
 import { literalInterpreter } from "./literal";
@@ -19,6 +20,7 @@ const schemaHandlers: SchemaInterpreterMap = {
   ...stringInterpreter,
   ...bigintInterpreter,
   ...dateInterpreter,
+  ...enumInterpreter,
   ...literalInterpreter,
   ...numberInterpreter,
   ...primitivesInterpreter,

--- a/packages/plugin-zod/tests/enum-interpreter.test.ts
+++ b/packages/plugin-zod/tests/enum-interpreter.test.ts
@@ -1,0 +1,85 @@
+import { composeInterpreters, coreInterpreter, mvfm, strInterpreter } from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { zod, zodInterpreter } from "../src/index";
+
+/** Inject input data into core/input nodes throughout the AST. */
+function injectInput(node: any, input: Record<string, unknown>): any {
+  if (node === null || node === undefined || typeof node !== "object") return node;
+  if (Array.isArray(node)) return node.map((n) => injectInput(n, input));
+  const result: any = {};
+  for (const [k, v] of Object.entries(node)) {
+    result[k] = injectInput(v, input);
+  }
+  if (result.kind === "core/input") result.__inputData = input;
+  return result;
+}
+
+/** Build AST from DSL, inject input, compose interpreters, evaluate. */
+async function run(prog: { ast: any }, input: Record<string, unknown> = {}) {
+  const ast = injectInput(prog.ast, input);
+  const interp = composeInterpreters([coreInterpreter, strInterpreter, zodInterpreter]);
+  return await interp(ast.result);
+}
+
+const app = mvfm(zod);
+
+describe("zodInterpreter: enum schemas (#145)", () => {
+  it("enum accepts valid value", async () => {
+    const prog = app(($) => $.zod.enum(["Salmon", "Tuna", "Trout"]).parse($.input.value));
+    expect(await run(prog, { value: "Salmon" })).toBe("Salmon");
+  });
+
+  it("enum rejects invalid value", async () => {
+    const prog = app(($) => $.zod.enum(["Salmon", "Tuna", "Trout"]).safeParse($.input.value));
+    const result = (await run(prog, { value: "Bass" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("enum with error config", async () => {
+    const prog = app(($) => $.zod.enum(["a", "b"], "Must be a or b").safeParse($.input.value));
+    const result = (await run(prog, { value: "c" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Must be a or b");
+  });
+
+  it("extract() validates only extracted values", async () => {
+    const prog = app(($) =>
+      $.zod.enum(["Salmon", "Tuna", "Trout"]).extract(["Salmon", "Trout"]).safeParse($.input.value),
+    );
+    const salmon = (await run(prog, { value: "Salmon" })) as any;
+    const tuna = (await run(prog, { value: "Tuna" })) as any;
+    expect(salmon.success).toBe(true);
+    expect(tuna.success).toBe(false);
+  });
+
+  it("exclude() rejects excluded values", async () => {
+    const prog = app(($) =>
+      $.zod.enum(["Salmon", "Tuna", "Trout"]).exclude(["Salmon"]).safeParse($.input.value),
+    );
+    const salmon = (await run(prog, { value: "Salmon" })) as any;
+    const tuna = (await run(prog, { value: "Tuna" })) as any;
+    expect(salmon.success).toBe(false);
+    expect(tuna.success).toBe(true);
+  });
+
+  it("nativeEnum accepts valid value", async () => {
+    const MyEnum = { Salmon: 0, Tuna: 1, Trout: 2 } as const;
+    const prog = app(($) => $.zod.nativeEnum(MyEnum).parse($.input.value));
+    expect(await run(prog, { value: 0 })).toBe(0);
+  });
+
+  it("nativeEnum rejects invalid value", async () => {
+    const MyEnum = { Salmon: 0, Tuna: 1 } as const;
+    const prog = app(($) => $.zod.nativeEnum(MyEnum).safeParse($.input.value));
+    const result = (await run(prog, { value: 99 })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("enum with optional wrapper", async () => {
+    const prog = app(($) => $.zod.enum(["a", "b"]).optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "a" })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+  });
+});

--- a/packages/plugin-zod/tests/enum.test.ts
+++ b/packages/plugin-zod/tests/enum.test.ts
@@ -1,0 +1,93 @@
+import { mvfm } from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { ZodEnumBuilder, ZodNativeEnumBuilder, zod } from "../src/index";
+
+// Helper: strip __id from AST for snapshot-stable assertions
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+describe("enum schemas (#108)", () => {
+  it("$.zod.enum() returns a ZodEnumBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.enum(["Salmon", "Tuna"]);
+      expect(builder).toBeInstanceOf(ZodEnumBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("enum produces correct AST", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.enum(["Salmon", "Tuna", "Trout"]).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/enum");
+    expect(ast.result.schema.values).toEqual(["Salmon", "Tuna", "Trout"]);
+  });
+
+  it("enum accepts error config", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.enum(["a", "b"], "Invalid!").parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.error).toBe("Invalid!");
+  });
+
+  it("extract() produces sub-enum", () => {
+    const app = mvfm(zod);
+    const prog = app(($) =>
+      $.zod.enum(["Salmon", "Tuna", "Trout"]).extract(["Salmon", "Trout"]).parse($.input),
+    );
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/enum");
+    expect(ast.result.schema.values).toEqual(["Salmon", "Trout"]);
+  });
+
+  it("exclude() removes values from enum", () => {
+    const app = mvfm(zod);
+    const prog = app(($) =>
+      $.zod.enum(["Salmon", "Tuna", "Trout"]).exclude(["Salmon"]).parse($.input),
+    );
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/enum");
+    expect(ast.result.schema.values).toEqual(["Tuna", "Trout"]);
+  });
+
+  it("enum supports wrappers", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.enum(["a", "b"]).optional().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/enum");
+  });
+
+  it("nativeEnum produces correct AST", () => {
+    const app = mvfm(zod);
+    const MyEnum = { Salmon: 0, Tuna: 1, Trout: 2 } as const;
+    const prog = app(($) => $.zod.nativeEnum(MyEnum).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/native_enum");
+    expect(ast.result.schema.entries).toEqual({ Salmon: 0, Tuna: 1, Trout: 2 });
+  });
+
+  it("$.zod.nativeEnum() returns a ZodNativeEnumBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.nativeEnum({ A: 0 });
+      expect(builder).toBeInstanceOf(ZodNativeEnumBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("enum inherits refinement methods", () => {
+    const app = mvfm(zod);
+    const prog = app(($) =>
+      $.zod
+        .enum(["a", "b"])
+        .refine((val) => val, { error: "must be valid" })
+        .parse($.input),
+    );
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.refinements).toHaveLength(1);
+    expect(ast.result.schema.refinements[0].kind).toBe("refine");
+  });
+});


### PR DESCRIPTION
Closes #108
Closes #145

## What this does

Adds `$.zod.enum()` for string-based enums with `.extract()` and `.exclude()` sub-enum derivation, and `$.zod.nativeEnum()` for TypeScript enum/object literal validation. Both produce AST nodes (`zod/enum`, `zod/native_enum`) with the interpreter dispatching to `z.enum()` and `z.nativeEnum()`.

## Design alignment

- **AST-first**: Enum values/entries stored as data in AST nodes
- **Plugin contract**: Two new node kinds registered in `nodeKinds`
- **Deterministic**: Same DSL call always produces the same AST

## Validation performed

- `npm run build` — all packages compile
- `npm run check` — biome + tsc pass
- `npm test` — 91 plugin-zod tests pass (8 new AST + 8 new interpreter tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Zod enum support with string-based and native TypeScript enum schema builders
  * Introduced extract and exclude operations to derive enums from existing definitions
  * Enhanced error message configuration for enum validation

* **Tests**
  * Added extensive test coverage for enum functionality and integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->