### PR TITLE
feat: tuple schema builder with interpreter (#111, #148)

### DIFF
--- a/packages/plugin-zod/src/base.ts
+++ b/packages/plugin-zod/src/base.ts
@@ -72,7 +72,8 @@ export abstract class ZodSchemaBuilder<T> {
 
   /**
    * Get the schema AST node for this builder.
-   * Used by composite schemas to embed inner schemas into their own AST nodes.
+   * Used by composite schemas (object, array, tuple, etc.) to embed
+   * field schemas into their own AST nodes.
    */
   get __schemaNode(): SchemaASTNode | WrapperASTNode {
     return this._buildSchemaNode();

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -21,6 +21,8 @@ import type { ZodStringNamespace } from "./string";
 import { stringNamespace, stringNodeKinds } from "./string";
 import type { ZodStringFormatsNamespace } from "./string-formats";
 import { stringFormatsNamespace, stringFormatsNodeKinds } from "./string-formats";
+import type { ZodTupleNamespace } from "./tuple";
+import { tupleNamespace, tupleNodeKinds } from "./tuple";
 
 // Re-export types, builders, and interpreter for consumers
 export { ZodArrayBuilder } from "./array";
@@ -38,6 +40,7 @@ export { ZodPrimitiveBuilder } from "./primitives";
 export { ZodStringBuilder } from "./string";
 export type { ZodIsoNamespace, ZodStringFormatsNamespace } from "./string-formats";
 export { buildStringFormat } from "./string-formats";
+export { ZodTupleBuilder } from "./tuple";
 export type {
   CheckDescriptor,
   ErrorConfig,
@@ -46,6 +49,11 @@ export type {
   ValidationASTNode,
   WrapperASTNode,
 } from "./types";
+
+/** Helper to extract error string from the common `errorOrOpts` parameter pattern. */
+function parseError(errorOrOpts?: string | { error?: string }): string | undefined {
+  return typeof errorOrOpts === "string" ? errorOrOpts : errorOrOpts?.error;
+}
 
 /**
  * The `$.zod` namespace contributed by the Zod plugin.
@@ -67,15 +75,11 @@ export interface ZodNamespace
     ZodNumberNamespace,
     ZodObjectNamespace,
     ZodPrimitivesNamespace,
-    ZodStringFormatsNamespace {
+    ZodStringFormatsNamespace,
+    ZodTupleNamespace {
   /** Coercion constructors -- convert input before validating. */
   coerce: ZodCoerceNamespace;
   // ^^^ Each new schema type adds ONE extends clause here
-}
-
-/** Parse error config from the standard `errorOrOpts` param. */
-function parseError(errorOrOpts?: string | { error?: string }): string | undefined {
-  return typeof errorOrOpts === "string" ? errorOrOpts : errorOrOpts?.error;
 }
 
 /** Parsing and wrapper node kinds shared across all schema types. */
@@ -120,6 +124,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...primitivesNodeKinds,
     ...coerceNodeKinds,
     ...stringFormatsNodeKinds,
+    ...tupleNodeKinds,
     // ^^^ Each new schema type adds ONE spread here
   ],
 
@@ -137,6 +142,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...primitivesNamespace(ctx, parseError),
         ...coerceNamespace(ctx, parseError),
         ...stringFormatsNamespace(ctx, parseError),
+        ...tupleNamespace(ctx, parseError),
         // ^^^ Each new schema type adds ONE spread here
       } as ZodNamespace,
     };

--- a/packages/plugin-zod/src/tuple.ts
+++ b/packages/plugin-zod/src/tuple.ts
@@ -1,0 +1,88 @@
+import type { ASTNode, PluginContext } from "@mvfm/core";
+import { ZodSchemaBuilder } from "./base";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  SchemaASTNode,
+  WrapperASTNode,
+} from "./types";
+
+/**
+ * Builder for Zod tuple schemas.
+ *
+ * Represents fixed-length typed arrays with optional variadic rest element.
+ * Items are stored as AST nodes in the `items` extra field, and the optional
+ * rest element in the `rest` extra field.
+ *
+ * @typeParam T - The tuple output type
+ */
+export class ZodTupleBuilder<T extends unknown[]> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/tuple", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodTupleBuilder<T> {
+    return new ZodTupleBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Convert an array of schema builders to an array of AST nodes. */
+export function itemsToAST(items: ZodSchemaBuilder<unknown>[]): (SchemaASTNode | WrapperASTNode)[] {
+  return items.map((builder) => builder.__schemaNode);
+}
+
+/** Node kinds registered by the tuple schema. */
+export const tupleNodeKinds: string[] = ["zod/tuple"];
+
+/**
+ * Namespace fragment for tuple schema factories.
+ */
+export interface ZodTupleNamespace {
+  /** Create a tuple schema builder with fixed items and optional rest element. */
+  tuple<T extends unknown[]>(
+    items: { [K in keyof T]: ZodSchemaBuilder<T[K]> },
+    rest?: ZodSchemaBuilder<unknown>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodTupleBuilder<T>;
+}
+
+/** Build the tuple namespace factory methods. */
+export function tupleNamespace(
+  ctx: PluginContext,
+  parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodTupleNamespace {
+  return {
+    tuple<T extends unknown[]>(
+      items: { [K in keyof T]: ZodSchemaBuilder<T[K]> },
+      rest?: ZodSchemaBuilder<unknown>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodTupleBuilder<T> {
+      const error = parseError(errorOrOpts);
+      const extra: Record<string, unknown> = {
+        items: itemsToAST(items as ZodSchemaBuilder<unknown>[]),
+      };
+      if (rest) {
+        extra.rest = rest.__schemaNode;
+      }
+      return new ZodTupleBuilder<T>(ctx, [], [], error, extra);
+    },
+  };
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -4,6 +4,7 @@ import {
   ZodNumberBuilder,
   ZodPrimitiveBuilder,
   ZodStringBuilder,
+  ZodTupleBuilder,
   ZodWrappedBuilder,
   zod,
 } from "../src/index";
@@ -745,5 +746,67 @@ describe("primitive types (#104)", () => {
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.kind).toBe("zod/optional");
     expect(ast.result.schema.inner.kind).toBe("zod/boolean");
+  });
+});
+describe("tuple schemas (#111)", () => {
+  it("$.zod.tuple() returns a ZodTupleBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.tuple([$.zod.string()]);
+      expect(builder).toBeInstanceOf(ZodTupleBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.tuple() produces zod/tuple AST with items", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.tuple([$.zod.string(), $.zod.string()]).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/tuple");
+    expect(ast.result.schema.items).toHaveLength(2);
+    expect(ast.result.schema.items[0].kind).toBe("zod/string");
+    expect(ast.result.schema.items[1].kind).toBe("zod/string");
+  });
+
+  it("$.zod.tuple() with rest element", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.tuple([$.zod.string()], $.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/tuple");
+    expect(ast.result.schema.items).toHaveLength(1);
+    expect(ast.result.schema.rest).toBeDefined();
+    expect(ast.result.schema.rest.kind).toBe("zod/string");
+  });
+
+  it("$.zod.tuple() without rest omits rest field", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.tuple([$.zod.string()]).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.rest).toBeUndefined();
+  });
+
+  it("$.zod.tuple() accepts error param", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.tuple([$.zod.string()], undefined, "Must be tuple!").parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.error).toBe("Must be tuple!");
+  });
+
+  it("wrappers work on tuple schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.tuple([$.zod.string()]).optional().parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/tuple");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -703,3 +703,61 @@ describe("zodInterpreter: primitives (#141)", () => {
     expect(valid.success).toBe(true);
   });
 });
+describe("zodInterpreter: tuple schemas (#148)", () => {
+  it("tuple of strings accepts valid input", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string(), $.zod.string()]).parse($.input.value));
+    expect(await run(prog, { value: ["a", "b"] })).toEqual(["a", "b"]);
+  });
+
+  it("tuple rejects non-array input", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string()]).safeParse($.input.value));
+    const result = (await run(prog, { value: "not a tuple" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("tuple rejects wrong number of elements", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string(), $.zod.string()]).safeParse($.input.value));
+    const result = (await run(prog, { value: ["only one"] })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("tuple rejects wrong element types", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string()]).safeParse($.input.value));
+    const result = (await run(prog, { value: [42] })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("tuple with rest element accepts extra elements", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string()], $.zod.string()).parse($.input.value));
+    expect(await run(prog, { value: ["a", "b", "c"] })).toEqual(["a", "b", "c"]);
+  });
+
+  it("tuple with rest element validates rest type", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string()], $.zod.string()).safeParse($.input.value));
+    const result = (await run(prog, { value: ["a", 42] })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("empty tuple accepts empty array", async () => {
+    const prog = app(($) => $.zod.tuple([]).parse($.input.value));
+    expect(await run(prog, { value: [] })).toEqual([]);
+  });
+
+  it("schema-level error appears in output", async () => {
+    const prog = app(($) =>
+      $.zod.tuple([$.zod.string()], undefined, "Must be tuple!").safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Must be tuple!");
+  });
+
+  it("optional tuple works", async () => {
+    const prog = app(($) => $.zod.tuple([$.zod.string()]).optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: ["a"] })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+    expect(valid.data).toEqual(["a"]);
+  });
+});


### PR DESCRIPTION
Closes #111
Closes #148

## What this does
Implements `$.zod.tuple(items, rest?)` producing `{ kind: "zod/tuple", items: SchemaNode[], rest?: SchemaNode }` AST nodes. The interpreter reconstructs `z.tuple(items)` with optional `.rest(schema)`, recursing into each item schema.

## Design alignment
- **Immutable chaining**: `ZodTupleBuilder` returns new instances via `_clone()`
- **AST determinism**: Items stored as AST node array, rest as optional AST node
- **Plugin namespace**: `zod/tuple` registered in `nodeKinds`
- **Composite schema pattern**: Uses `__schemaNode` getter and `itemsToAST()` helper

## Validation performed
- `pnpm run -r build` — all packages compile cleanly
- `npx biome check` — lint/format pass
- `npx vitest run packages/plugin-zod` — 90 tests pass (42 AST + 48 interpreter)
- New tests: 6 AST tests + 9 interpreter round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zod tuple schemas with fixed items and optional rest elements.
  * Tuple schemas now support error handling and validation of tuple structure and element types.
  * Optional tuple wrapping is now available for additional schema composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->