### PR TITLE
feat: union/xor schema builders with interpreter (#112, #149)

### DIFF
--- a/packages/plugin-zod/src/base.ts
+++ b/packages/plugin-zod/src/base.ts
@@ -72,8 +72,8 @@ export abstract class ZodSchemaBuilder<T> {
 
   /**
    * Get the schema AST node for this builder.
-   * Used by composite schemas (object, array, tuple, etc.) to embed
-   * field schemas into their own AST nodes.
+   * Used by composite schemas (object, array, tuple, union, etc.) to embed
+   * inner schemas into their own AST nodes.
    */
   get __schemaNode(): SchemaASTNode | WrapperASTNode {
     return this._buildSchemaNode();

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -23,6 +23,8 @@ import type { ZodStringFormatsNamespace } from "./string-formats";
 import { stringFormatsNamespace, stringFormatsNodeKinds } from "./string-formats";
 import type { ZodTupleNamespace } from "./tuple";
 import { tupleNamespace, tupleNodeKinds } from "./tuple";
+import type { ZodUnionNamespace } from "./union";
+import { unionNamespace, unionNodeKinds } from "./union";
 
 // Re-export types, builders, and interpreter for consumers
 export { ZodArrayBuilder } from "./array";
@@ -49,6 +51,7 @@ export type {
   ValidationASTNode,
   WrapperASTNode,
 } from "./types";
+export { ZodUnionBuilder } from "./union";
 
 /** Helper to extract error string from the common `errorOrOpts` parameter pattern. */
 function parseError(errorOrOpts?: string | { error?: string }): string | undefined {
@@ -76,7 +79,8 @@ export interface ZodNamespace
     ZodObjectNamespace,
     ZodPrimitivesNamespace,
     ZodStringFormatsNamespace,
-    ZodTupleNamespace {
+    ZodTupleNamespace,
+    ZodUnionNamespace {
   /** Coercion constructors -- convert input before validating. */
   coerce: ZodCoerceNamespace;
   // ^^^ Each new schema type adds ONE extends clause here
@@ -125,6 +129,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...coerceNodeKinds,
     ...stringFormatsNodeKinds,
     ...tupleNodeKinds,
+    ...unionNodeKinds,
     // ^^^ Each new schema type adds ONE spread here
   ],
 
@@ -143,6 +148,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...coerceNamespace(ctx, parseError),
         ...stringFormatsNamespace(ctx, parseError),
         ...tupleNamespace(ctx, parseError),
+        ...unionNamespace(ctx, parseError),
         // ^^^ Each new schema type adds ONE spread here
       } as ZodNamespace,
     };

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -13,6 +13,7 @@ import { createObjectInterpreter } from "./object";
 import { primitivesInterpreter } from "./primitives";
 import { stringInterpreter } from "./string";
 import type { ErrorConfig, RefinementDescriptor } from "./types";
+import { createUnionInterpreter } from "./union";
 
 // ---- Schema handler dispatch ----
 // Each schema module exports an interpreter map.
@@ -29,7 +30,7 @@ const leafHandlers: SchemaInterpreterMap = {
   ...primitivesInterpreter,
 };
 
-// Recursive handlers (array, object) need buildSchemaGen for inner schemas.
+// Recursive handlers (array, object, union) need buildSchemaGen for inner schemas.
 // Initialized lazily on first use to break the definition-order cycle.
 let schemaHandlers: SchemaInterpreterMap | undefined;
 
@@ -40,6 +41,7 @@ function getHandlers(): SchemaInterpreterMap {
       ...leafHandlers,
       ...createObjectInterpreter(buildSchemaGen),
       ...createArrayInterpreter(buildSchemaGen),
+      ...createUnionInterpreter(buildSchemaGen),
     };
   }
   return schemaHandlers;

--- a/packages/plugin-zod/src/union.ts
+++ b/packages/plugin-zod/src/union.ts
@@ -1,0 +1,138 @@
+import type { ASTNode, PluginContext, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import { toZodError } from "./interpreter-utils";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  SchemaASTNode,
+  WrapperASTNode,
+} from "./types";
+
+/**
+ * Builder for Zod union and exclusive-or (xor) schemas.
+ *
+ * Stores option schemas as AST nodes in the `options` extra field.
+ * Used for both `$.zod.union(...)` and `$.zod.xor(...)`.
+ *
+ * @typeParam T - The union output type
+ */
+export class ZodUnionBuilder<T> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    kind: "zod/union" | "zod/xor",
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, kind, checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodUnionBuilder<T> {
+    return new ZodUnionBuilder<T>(
+      this._ctx,
+      this._kind as "zod/union" | "zod/xor",
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Convert an array of schema builders to an array of AST nodes. */
+export function optionsToAST(
+  options: ZodSchemaBuilder<unknown>[],
+): (SchemaASTNode | WrapperASTNode)[] {
+  return options.map((builder) => builder.__schemaNode);
+}
+
+/** Node kinds registered by the union schema. */
+export const unionNodeKinds: string[] = ["zod/union", "zod/xor"];
+
+/**
+ * Namespace fragment for union schema factories.
+ */
+export interface ZodUnionNamespace {
+  /** Create a union schema builder (A | B | ...). */
+  union<T extends unknown[]>(
+    options: { [K in keyof T]: ZodSchemaBuilder<T[K]> },
+    errorOrOpts?: string | { error?: string },
+  ): ZodUnionBuilder<T[number]>;
+
+  /** Create an exclusive union schema builder (exactly one must match). */
+  xor<T extends unknown[]>(
+    options: { [K in keyof T]: ZodSchemaBuilder<T[K]> },
+    errorOrOpts?: string | { error?: string },
+  ): ZodUnionBuilder<T[number]>;
+}
+
+/** Build the union namespace factory methods. */
+export function unionNamespace(
+  ctx: PluginContext,
+  parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodUnionNamespace {
+  return {
+    union<T extends unknown[]>(
+      options: { [K in keyof T]: ZodSchemaBuilder<T[K]> },
+      errorOrOpts?: string | { error?: string },
+    ): ZodUnionBuilder<T[number]> {
+      const error = parseError(errorOrOpts);
+      return new ZodUnionBuilder<T[number]>(ctx, "zod/union", [], [], error, {
+        options: optionsToAST(options as ZodSchemaBuilder<unknown>[]),
+      });
+    },
+
+    xor<T extends unknown[]>(
+      options: { [K in keyof T]: ZodSchemaBuilder<T[K]> },
+      errorOrOpts?: string | { error?: string },
+    ): ZodUnionBuilder<T[number]> {
+      const error = parseError(errorOrOpts);
+      return new ZodUnionBuilder<T[number]>(ctx, "zod/xor", [], [], error, {
+        options: optionsToAST(options as ZodSchemaBuilder<unknown>[]),
+      });
+    },
+  };
+}
+
+/**
+ * Build a Zod schema from a field's AST node by delegating to the
+ * interpreter's buildSchemaGen. This is passed in at registration time
+ * to avoid circular imports.
+ */
+type SchemaBuildFn = (node: ASTNode) => Generator<StepEffect, z.ZodType, unknown>;
+
+/** Create union interpreter handlers with access to the shared schema builder. */
+export function createUnionInterpreter(buildSchema: SchemaBuildFn): SchemaInterpreterMap {
+  return {
+    "zod/union": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+      const optionNodes = (node.options as ASTNode[]) ?? [];
+      const errorFn = toZodError(node.error as ErrorConfig | undefined);
+      const errOpt = errorFn ? { error: errorFn } : {};
+      const builtOptions: z.ZodType[] = [];
+      for (const optNode of optionNodes) {
+        builtOptions.push(yield* buildSchema(optNode));
+      }
+      return z.union(builtOptions as [z.ZodType, z.ZodType, ...z.ZodType[]], errOpt);
+    },
+
+    "zod/xor": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+      const optionNodes = (node.options as ASTNode[]) ?? [];
+      const errorFn = toZodError(node.error as ErrorConfig | undefined);
+      const errOpt = errorFn ? { error: errorFn } : {};
+      const builtOptions: z.ZodType[] = [];
+      for (const optNode of optionNodes) {
+        builtOptions.push(yield* buildSchema(optNode));
+      }
+      return (z as any).xor(builtOptions as [z.ZodType, z.ZodType, ...z.ZodType[]], errOpt);
+    },
+  };
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -5,6 +5,7 @@ import {
   ZodPrimitiveBuilder,
   ZodStringBuilder,
   ZodTupleBuilder,
+  ZodUnionBuilder,
   ZodWrappedBuilder,
   zod,
 } from "../src/index";
@@ -808,5 +809,57 @@ describe("tuple schemas (#111)", () => {
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.kind).toBe("zod/optional");
     expect(ast.result.schema.inner.kind).toBe("zod/tuple");
+  });
+});
+
+describe("union/xor schemas (#112)", () => {
+  it("$.zod.union() returns a ZodUnionBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.union([$.zod.string(), $.zod.string()]);
+      expect(builder).toBeInstanceOf(ZodUnionBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.union() produces zod/union AST with options", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.union([$.zod.string(), $.zod.string()]).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/union");
+    expect(ast.result.schema.options).toHaveLength(2);
+    expect(ast.result.schema.options[0].kind).toBe("zod/string");
+    expect(ast.result.schema.options[1].kind).toBe("zod/string");
+  });
+
+  it("$.zod.union() accepts error param", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.union([$.zod.string(), $.zod.string()], "Bad union!").parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.error).toBe("Bad union!");
+  });
+
+  it("$.zod.xor() produces zod/xor AST", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.xor([$.zod.string(), $.zod.string()]).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/xor");
+    expect(ast.result.schema.options).toHaveLength(2);
+  });
+
+  it("wrappers work on union schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.union([$.zod.string(), $.zod.string()]).optional().parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/union");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -761,3 +761,51 @@ describe("zodInterpreter: tuple schemas (#148)", () => {
     expect(valid.data).toEqual(["a"]);
   });
 });
+
+describe("zodInterpreter: union/xor schemas (#149)", () => {
+  it("union accepts value matching first option", async () => {
+    const prog = app(($) =>
+      $.zod.union([$.zod.string().min(1), $.zod.string().min(5)]).parse($.input.value),
+    );
+    expect(await run(prog, { value: "hi" })).toBe("hi");
+  });
+
+  it("union rejects non-matching input", async () => {
+    const prog = app(($) => $.zod.union([$.zod.string(), $.zod.string()]).safeParse($.input.value));
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("union with schema-level error", async () => {
+    const prog = app(($) =>
+      $.zod.union([$.zod.string(), $.zod.string()], "Must match!").safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toContain("Must match!");
+  });
+
+  it("union with optional wrapper", async () => {
+    const prog = app(($) =>
+      $.zod.union([$.zod.string(), $.zod.string()]).optional().safeParse($.input.value),
+    );
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "hi" })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+  });
+
+  it("xor accepts value matching exactly one option", async () => {
+    const prog = app(($) =>
+      $.zod.xor([$.zod.string().min(5), $.zod.string().max(3)]).parse($.input.value),
+    );
+    // "hello!" matches min(5) but not max(3) → exactly one match → passes
+    expect(await run(prog, { value: "hello!" })).toBe("hello!");
+  });
+
+  it("xor rejects non-matching input", async () => {
+    const prog = app(($) => $.zod.xor([$.zod.string(), $.zod.string()]).safeParse($.input.value));
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #112
Closes #149

## What this does
Implements `$.zod.union(options)` and `$.zod.xor(options)` producing `{ kind: "zod/union"|"zod/xor", options: SchemaNode[] }` AST nodes. Both share `ZodUnionBuilder` parameterized by kind. The interpreter reconstructs `z.union(options)` and `z.xor(options)`, recursing into each option schema.

## Design alignment
- **Immutable chaining**: `ZodUnionBuilder` returns new instances via `_clone()`
- **AST determinism**: Options stored as AST node array
- **Plugin namespace**: `zod/union` and `zod/xor` registered in `nodeKinds`
- **Composite schema pattern**: Uses `__schemaNode` getter and `optionsToAST()` helper

## Validation performed
- `pnpm run -r build` — all packages compile cleanly
- `npx biome check` — lint/format pass
- `npx vitest run packages/plugin-zod` — 86 tests pass (41 AST + 45 interpreter)
- New tests: 5 AST tests + 6 interpreter round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)