### PR TITLE
feat: intersection schema builder with interpreter (#114, #151)

### DIFF
--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -9,6 +9,8 @@ import type { ZodDateNamespace } from "./date";
 import { dateNamespace, dateNodeKinds } from "./date";
 import type { ZodEnumNamespace } from "./enum";
 import { enumNamespace, enumNodeKinds } from "./enum";
+import type { ZodIntersectionNamespace } from "./intersection";
+import { intersectionNamespace, intersectionNodeKinds } from "./intersection";
 import type { ZodLiteralNamespace } from "./literal";
 import { literalNamespace, literalNodeKinds } from "./literal";
 import type { ZodNumberNamespace } from "./number";
@@ -34,6 +36,7 @@ export { ZodDateBuilder } from "./date";
 export { ZodEnumBuilder, ZodNativeEnumBuilder } from "./enum";
 export { zodInterpreter } from "./interpreter";
 export type { SchemaInterpreterMap } from "./interpreter-utils";
+export { ZodIntersectionBuilder } from "./intersection";
 export { ZodLiteralBuilder } from "./literal";
 export { ZodNumberBuilder } from "./number";
 export type { ShapeInput } from "./object";
@@ -74,6 +77,7 @@ export interface ZodNamespace
     ZodBigIntNamespace,
     ZodDateNamespace,
     ZodEnumNamespace,
+    ZodIntersectionNamespace,
     ZodLiteralNamespace,
     ZodNumberNamespace,
     ZodObjectNamespace,
@@ -122,6 +126,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...bigintNodeKinds,
     ...dateNodeKinds,
     ...enumNodeKinds,
+    ...intersectionNodeKinds,
     ...literalNodeKinds,
     ...numberNodeKinds,
     ...objectNodeKinds,
@@ -141,6 +146,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...bigintNamespace(ctx, parseError),
         ...dateNamespace(ctx, parseError),
         ...enumNamespace(ctx, parseError),
+        ...intersectionNamespace(ctx, parseError),
         ...literalNamespace(ctx),
         ...numberNamespace(ctx, parseError),
         ...objectNamespace(ctx, parseError),

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -7,6 +7,7 @@ import { dateInterpreter } from "./date";
 import { enumInterpreter } from "./enum";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { toZodError } from "./interpreter-utils";
+import { createIntersectionInterpreter } from "./intersection";
 import { literalInterpreter } from "./literal";
 import { numberInterpreter } from "./number";
 import { createObjectInterpreter } from "./object";
@@ -30,7 +31,7 @@ const leafHandlers: SchemaInterpreterMap = {
   ...primitivesInterpreter,
 };
 
-// Recursive handlers (array, object, union) need buildSchemaGen for inner schemas.
+// Recursive handlers (array, object, union, intersection) need buildSchemaGen for inner schemas.
 // Initialized lazily on first use to break the definition-order cycle.
 let schemaHandlers: SchemaInterpreterMap | undefined;
 
@@ -42,6 +43,7 @@ function getHandlers(): SchemaInterpreterMap {
       ...createObjectInterpreter(buildSchemaGen),
       ...createArrayInterpreter(buildSchemaGen),
       ...createUnionInterpreter(buildSchemaGen),
+      ...createIntersectionInterpreter(buildSchemaGen),
     };
   }
   return schemaHandlers;

--- a/packages/plugin-zod/src/intersection.ts
+++ b/packages/plugin-zod/src/intersection.ts
@@ -1,0 +1,98 @@
+import type { ASTNode, PluginContext, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  SchemaASTNode,
+  WrapperASTNode,
+} from "./types";
+
+/**
+ * Builder for Zod intersection schemas (A & B).
+ *
+ * Stores left and right schemas as AST nodes in extra fields.
+ *
+ * @typeParam T - The intersection output type
+ */
+export class ZodIntersectionBuilder<T> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/intersection", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodIntersectionBuilder<T> {
+    return new ZodIntersectionBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Node kinds registered by the intersection schema. */
+export const intersectionNodeKinds: string[] = ["zod/intersection"];
+
+/**
+ * Namespace fragment for intersection schema factory.
+ */
+export interface ZodIntersectionNamespace {
+  /** Create an intersection schema builder (A & B). */
+  intersection<A, B>(
+    left: ZodSchemaBuilder<A>,
+    right: ZodSchemaBuilder<B>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodIntersectionBuilder<A & B>;
+}
+
+/** Build the intersection namespace factory methods. */
+export function intersectionNamespace(
+  ctx: PluginContext,
+  parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodIntersectionNamespace {
+  return {
+    intersection<A, B>(
+      left: ZodSchemaBuilder<A>,
+      right: ZodSchemaBuilder<B>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodIntersectionBuilder<A & B> {
+      const error = parseError(errorOrOpts);
+      return new ZodIntersectionBuilder<A & B>(ctx, [], [], error, {
+        left: (left as ZodSchemaBuilder<unknown>).__schemaNode as SchemaASTNode | WrapperASTNode,
+        right: (right as ZodSchemaBuilder<unknown>).__schemaNode as SchemaASTNode | WrapperASTNode,
+      });
+    },
+  };
+}
+
+/**
+ * Build a Zod schema from a field's AST node by delegating to the
+ * interpreter's buildSchemaGen. This is passed in at registration time
+ * to avoid circular imports.
+ */
+type SchemaBuildFn = (node: ASTNode) => Generator<StepEffect, z.ZodType, unknown>;
+
+/** Create intersection interpreter handlers with access to the shared schema builder. */
+export function createIntersectionInterpreter(buildSchema: SchemaBuildFn): SchemaInterpreterMap {
+  return {
+    "zod/intersection": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+      const leftSchema = yield* buildSchema(node.left as ASTNode);
+      const rightSchema = yield* buildSchema(node.right as ASTNode);
+      return z.intersection(leftSchema, rightSchema);
+    },
+  };
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -1,6 +1,7 @@
 import { mvfm } from "@mvfm/core";
 import { describe, expect, it } from "vitest";
 import {
+  ZodIntersectionBuilder,
   ZodNumberBuilder,
   ZodPrimitiveBuilder,
   ZodStringBuilder,
@@ -861,5 +862,51 @@ describe("union/xor schemas (#112)", () => {
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.kind).toBe("zod/optional");
     expect(ast.result.schema.inner.kind).toBe("zod/union");
+  });
+});
+
+describe("intersection schemas (#114)", () => {
+  it("$.zod.intersection() returns a ZodIntersectionBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.intersection($.zod.string(), $.zod.string());
+      expect(builder).toBeInstanceOf(ZodIntersectionBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.intersection() produces zod/intersection AST with left and right", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.intersection($.zod.string(), $.zod.string().min(3)).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/intersection");
+    expect(ast.result.schema.left).toBeDefined();
+    expect(ast.result.schema.left.kind).toBe("zod/string");
+    expect(ast.result.schema.right).toBeDefined();
+    expect(ast.result.schema.right.kind).toBe("zod/string");
+    expect(ast.result.schema.right.checks).toHaveLength(1);
+  });
+
+  it("$.zod.intersection() accepts error param", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod
+        .intersection($.zod.string(), $.zod.string(), "Intersection fail!")
+        .parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.error).toBe("Intersection fail!");
+  });
+
+  it("wrappers work on intersection schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.intersection($.zod.string(), $.zod.string()).optional().parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/intersection");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -809,3 +809,38 @@ describe("zodInterpreter: union/xor schemas (#149)", () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe("zodInterpreter: intersection schemas (#151)", () => {
+  it("intersection validates against both schemas", async () => {
+    const prog = app(($) =>
+      $.zod.intersection($.zod.string(), $.zod.string().min(3)).parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello" })).toBe("hello");
+  });
+
+  it("intersection rejects if left schema fails", async () => {
+    const prog = app(($) =>
+      $.zod.intersection($.zod.string(), $.zod.string()).safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: 42 })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("intersection rejects if right schema fails", async () => {
+    const prog = app(($) =>
+      $.zod.intersection($.zod.string(), $.zod.string().min(10)).safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: "hi" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("optional intersection works", async () => {
+    const prog = app(($) =>
+      $.zod.intersection($.zod.string(), $.zod.string()).optional().safeParse($.input.value),
+    );
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "hi" })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #114
Closes #151

## What this does
Implements `$.zod.intersection(left, right)` producing `{ kind: "zod/intersection", left: SchemaNode, right: SchemaNode }` AST nodes. The interpreter recurses both left and right schemas and constructs `z.intersection(left, right)`.

## Design alignment
- **Immutable chaining**: `ZodIntersectionBuilder` returns new instances via `_clone()`
- **AST determinism**: Left/right stored as AST node references
- **Plugin namespace**: `zod/intersection` registered in `nodeKinds`
- **Composite schema pattern**: Uses `__schemaNode` getter

## Validation performed
- `pnpm run -r build` — all packages compile cleanly
- `npx biome check` — lint/format pass
- `npx vitest run packages/plugin-zod` — 83 tests pass (40 AST + 43 interpreter)
- New tests: 4 AST tests + 4 interpreter round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)