### PR TITLE
feat: record schema builder with interpreter (#115, #152)

### DIFF
--- a/packages/plugin-zod/src/base.ts
+++ b/packages/plugin-zod/src/base.ts
@@ -72,7 +72,7 @@ export abstract class ZodSchemaBuilder<T> {
 
   /**
    * Get the schema AST node for this builder.
-   * Used by composite schemas (object, array, tuple, union, etc.) to embed
+   * Used by composite schemas (object, array, tuple, union, record, etc.) to embed
    * inner schemas into their own AST nodes.
    */
   get __schemaNode(): SchemaASTNode | WrapperASTNode {

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -19,6 +19,8 @@ import type { ZodObjectNamespace } from "./object";
 import { objectNamespace, objectNodeKinds } from "./object";
 import type { ZodPrimitivesNamespace } from "./primitives";
 import { primitivesNamespace, primitivesNodeKinds } from "./primitives";
+import type { ZodRecordNamespace } from "./record";
+import { recordNamespace, recordNodeKinds } from "./record";
 import type { ZodStringNamespace } from "./string";
 import { stringNamespace, stringNodeKinds } from "./string";
 import type { ZodStringFormatsNamespace } from "./string-formats";
@@ -42,6 +44,7 @@ export { ZodNumberBuilder } from "./number";
 export type { ShapeInput } from "./object";
 export { ZodObjectBuilder } from "./object";
 export { ZodPrimitiveBuilder } from "./primitives";
+export { ZodRecordBuilder } from "./record";
 export { ZodStringBuilder } from "./string";
 export type { ZodIsoNamespace, ZodStringFormatsNamespace } from "./string-formats";
 export { buildStringFormat } from "./string-formats";
@@ -82,6 +85,7 @@ export interface ZodNamespace
     ZodNumberNamespace,
     ZodObjectNamespace,
     ZodPrimitivesNamespace,
+    ZodRecordNamespace,
     ZodStringFormatsNamespace,
     ZodTupleNamespace,
     ZodUnionNamespace {
@@ -132,6 +136,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...objectNodeKinds,
     ...primitivesNodeKinds,
     ...coerceNodeKinds,
+    ...recordNodeKinds,
     ...stringFormatsNodeKinds,
     ...tupleNodeKinds,
     ...unionNodeKinds,
@@ -152,6 +157,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...objectNamespace(ctx, parseError),
         ...primitivesNamespace(ctx, parseError),
         ...coerceNamespace(ctx, parseError),
+        ...recordNamespace(ctx, parseError),
         ...stringFormatsNamespace(ctx, parseError),
         ...tupleNamespace(ctx, parseError),
         ...unionNamespace(ctx, parseError),

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -12,6 +12,7 @@ import { literalInterpreter } from "./literal";
 import { numberInterpreter } from "./number";
 import { createObjectInterpreter } from "./object";
 import { primitivesInterpreter } from "./primitives";
+import { createRecordInterpreter } from "./record";
 import { stringInterpreter } from "./string";
 import type { ErrorConfig, RefinementDescriptor } from "./types";
 import { createUnionInterpreter } from "./union";
@@ -31,7 +32,7 @@ const leafHandlers: SchemaInterpreterMap = {
   ...primitivesInterpreter,
 };
 
-// Recursive handlers (array, object, union, intersection) need buildSchemaGen for inner schemas.
+// Recursive handlers (array, object, union, intersection, record) need buildSchemaGen for inner schemas.
 // Initialized lazily on first use to break the definition-order cycle.
 let schemaHandlers: SchemaInterpreterMap | undefined;
 
@@ -44,6 +45,7 @@ function getHandlers(): SchemaInterpreterMap {
       ...createArrayInterpreter(buildSchemaGen),
       ...createUnionInterpreter(buildSchemaGen),
       ...createIntersectionInterpreter(buildSchemaGen),
+      ...createRecordInterpreter(buildSchemaGen),
     };
   }
   return schemaHandlers;
@@ -103,6 +105,7 @@ function* buildSchemaGen(node: ASTNode): Generator<StepEffect, z.ZodType, unknow
       }
       return tuple;
     }
+
     default:
       throw new Error(`Zod interpreter: unknown schema kind "${node.kind}"`);
   }

--- a/packages/plugin-zod/src/record.ts
+++ b/packages/plugin-zod/src/record.ts
@@ -1,0 +1,148 @@
+import type { ASTNode, PluginContext, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import { toZodError } from "./interpreter-utils";
+import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+
+/** Record mode: strict (exhaustive), partial (non-exhaustive), or loose (pass-through). */
+export type RecordMode = "strict" | "partial" | "loose";
+
+/**
+ * Builder for Zod record schemas.
+ *
+ * Stores key and value schemas as AST nodes in extra fields,
+ * along with a mode field for strict/partial/loose behavior.
+ *
+ * @typeParam K - The key type
+ * @typeParam V - The value type
+ */
+export class ZodRecordBuilder<K extends string, V> extends ZodSchemaBuilder<Record<K, V>> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/record", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodRecordBuilder<K, V> {
+    return new ZodRecordBuilder<K, V>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Node kinds contributed by the record schema. */
+export const recordNodeKinds: string[] = ["zod/record"];
+
+/**
+ * Namespace fragment for record schema factories.
+ */
+export interface ZodRecordNamespace {
+  /** Create a record schema builder (strict mode — exhaustive key check). */
+  record<K extends string, V>(
+    keySchema: ZodSchemaBuilder<K>,
+    valueSchema: ZodSchemaBuilder<V>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodRecordBuilder<K, V>;
+
+  /** Create a partial record schema builder (non-exhaustive key check). */
+  partialRecord<K extends string, V>(
+    keySchema: ZodSchemaBuilder<K>,
+    valueSchema: ZodSchemaBuilder<V>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodRecordBuilder<K, V>;
+
+  /** Create a loose record schema builder (non-matching keys pass through). */
+  looseRecord<K extends string, V>(
+    keySchema: ZodSchemaBuilder<K>,
+    valueSchema: ZodSchemaBuilder<V>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodRecordBuilder<K, V>;
+}
+
+/** Build the record namespace factory methods. */
+export function recordNamespace(
+  ctx: PluginContext,
+  parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodRecordNamespace {
+  function buildRecord<K extends string, V>(
+    keySchema: ZodSchemaBuilder<K>,
+    valueSchema: ZodSchemaBuilder<V>,
+    mode: string,
+    errorOrOpts?: string | { error?: string },
+  ): ZodRecordBuilder<K, V> {
+    const error = parseError(errorOrOpts);
+    return new ZodRecordBuilder<K, V>(ctx, [], [], error, {
+      key: keySchema.__schemaNode,
+      value: valueSchema.__schemaNode,
+      mode,
+    });
+  }
+
+  return {
+    record<K extends string, V>(
+      keySchema: ZodSchemaBuilder<K>,
+      valueSchema: ZodSchemaBuilder<V>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodRecordBuilder<K, V> {
+      return buildRecord(keySchema, valueSchema, "strict", errorOrOpts);
+    },
+
+    partialRecord<K extends string, V>(
+      keySchema: ZodSchemaBuilder<K>,
+      valueSchema: ZodSchemaBuilder<V>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodRecordBuilder<K, V> {
+      return buildRecord(keySchema, valueSchema, "partial", errorOrOpts);
+    },
+
+    looseRecord<K extends string, V>(
+      keySchema: ZodSchemaBuilder<K>,
+      valueSchema: ZodSchemaBuilder<V>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodRecordBuilder<K, V> {
+      return buildRecord(keySchema, valueSchema, "loose", errorOrOpts);
+    },
+  };
+}
+
+/**
+ * Build a Zod schema from a field's AST node by delegating to the
+ * interpreter's buildSchemaGen. This is passed in at registration time
+ * to avoid circular imports.
+ */
+type SchemaBuildFn = (node: ASTNode) => Generator<StepEffect, z.ZodType, unknown>;
+
+/** Create record interpreter handlers with access to the shared schema builder. */
+export function createRecordInterpreter(buildSchema: SchemaBuildFn): SchemaInterpreterMap {
+  return {
+    "zod/record": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+      const keySchema = yield* buildSchema(node.key as ASTNode);
+      const valueSchema = yield* buildSchema(node.value as ASTNode);
+      const mode = (node.mode as string) ?? "strict";
+      const errorFn = toZodError(node.error as ErrorConfig | undefined);
+      const errOpt = errorFn ? { error: errorFn } : {};
+      switch (mode) {
+        case "partial":
+          return (z as any).partialRecord(keySchema, valueSchema, errOpt);
+        case "loose":
+          return (z as any).looseRecord(keySchema, valueSchema, errOpt);
+        default:
+          return z.record(keySchema as z.ZodString, valueSchema, errOpt);
+      }
+    },
+  };
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -4,6 +4,7 @@ import {
   ZodIntersectionBuilder,
   ZodNumberBuilder,
   ZodPrimitiveBuilder,
+  ZodRecordBuilder,
   ZodStringBuilder,
   ZodTupleBuilder,
   ZodUnionBuilder,
@@ -908,5 +909,65 @@ describe("intersection schemas (#114)", () => {
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.kind).toBe("zod/optional");
     expect(ast.result.schema.inner.kind).toBe("zod/intersection");
+  });
+});
+
+describe("record schemas (#115)", () => {
+  it("$.zod.record() returns a ZodRecordBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.record($.zod.string(), $.zod.string());
+      expect(builder).toBeInstanceOf(ZodRecordBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.record() produces zod/record AST with key and value schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.record($.zod.string(), $.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/record");
+    expect(ast.result.schema.key.kind).toBe("zod/string");
+    expect(ast.result.schema.value.kind).toBe("zod/string");
+    expect(ast.result.schema.mode).toBe("strict");
+  });
+
+  it("$.zod.partialRecord() sets mode to partial", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.partialRecord($.zod.string(), $.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.mode).toBe("partial");
+  });
+
+  it("$.zod.looseRecord() sets mode to loose", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.looseRecord($.zod.string(), $.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.mode).toBe("loose");
+  });
+
+  it("$.zod.record() accepts error param", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.record($.zod.string(), $.zod.string(), "Bad record!").parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.error).toBe("Bad record!");
+  });
+
+  it("wrappers work on record schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.record($.zod.string(), $.zod.string()).optional().parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/record");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -844,3 +844,52 @@ describe("zodInterpreter: intersection schemas (#151)", () => {
     expect(valid.success).toBe(true);
   });
 });
+
+describe("zodInterpreter: record schemas (#152)", () => {
+  it("record accepts valid Record<string, string>", async () => {
+    const prog = app(($) => $.zod.record($.zod.string(), $.zod.string()).parse($.input.value));
+    expect(await run(prog, { value: { a: "hello", b: "world" } })).toEqual({
+      a: "hello",
+      b: "world",
+    });
+  });
+
+  it("record accepts empty object", async () => {
+    const prog = app(($) => $.zod.record($.zod.string(), $.zod.string()).parse($.input.value));
+    expect(await run(prog, { value: {} })).toEqual({});
+  });
+
+  it("record rejects non-object input", async () => {
+    const prog = app(($) => $.zod.record($.zod.string(), $.zod.string()).safeParse($.input.value));
+    const result = (await run(prog, { value: "not an object" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("record rejects invalid value types", async () => {
+    const prog = app(($) => $.zod.record($.zod.string(), $.zod.string()).safeParse($.input.value));
+    const result = (await run(prog, { value: { a: 42 } })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("partialRecord accepts valid input", async () => {
+    const prog = app(($) =>
+      $.zod.partialRecord($.zod.string(), $.zod.string()).parse($.input.value),
+    );
+    expect(await run(prog, { value: { x: "hi" } })).toEqual({ x: "hi" });
+  });
+
+  it("looseRecord accepts valid input", async () => {
+    const prog = app(($) => $.zod.looseRecord($.zod.string(), $.zod.string()).parse($.input.value));
+    expect(await run(prog, { value: { x: "hi" } })).toEqual({ x: "hi" });
+  });
+
+  it("optional record works", async () => {
+    const prog = app(($) =>
+      $.zod.record($.zod.string(), $.zod.string()).optional().safeParse($.input.value),
+    );
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: { a: "b" } })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #115
Closes #152

## What this does
Implements `$.zod.record(key, value)`, `$.zod.partialRecord(key, value)`, and `$.zod.looseRecord(key, value)` producing `{ kind: "zod/record", key: SchemaNode, value: SchemaNode, mode: "strict"|"partial"|"loose" }` AST nodes. The interpreter dispatches to `z.record()`, `z.partialRecord()`, or `z.looseRecord()` based on mode.

## Design alignment
- **Immutable chaining**: `ZodRecordBuilder` returns new instances via `_clone()`
- **AST determinism**: Key/value stored as AST nodes, mode as string
- **Plugin namespace**: `zod/record` registered in `nodeKinds`

## Validation performed
- `pnpm run -r build` — all packages compile cleanly
- `npx biome check` — lint/format pass
- `npx vitest run packages/plugin-zod` — 88 tests pass (42 AST + 46 interpreter)
- New tests: 6 AST tests + 7 interpreter round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zod record schemas with three variants: strict, partial, and loose modes for flexible key-value object validation.

* **Tests**
  * Added comprehensive test coverage for record schema validation, including input validation, error handling, and edge cases.

* **Documentation**
  * Updated schema node documentation to reflect record schema support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->