### PR TITLE
feat: map/set schema builders with interpreter (#116, #153)

### DIFF
--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -13,6 +13,8 @@ import type { ZodIntersectionNamespace } from "./intersection";
 import { intersectionNamespace, intersectionNodeKinds } from "./intersection";
 import type { ZodLiteralNamespace } from "./literal";
 import { literalNamespace, literalNodeKinds } from "./literal";
+import type { ZodMapSetNamespace } from "./map-set";
+import { mapSetNamespace, mapSetNodeKinds } from "./map-set";
 import type { ZodNumberNamespace } from "./number";
 import { numberNamespace, numberNodeKinds } from "./number";
 import type { ZodObjectNamespace } from "./object";
@@ -40,6 +42,7 @@ export { zodInterpreter } from "./interpreter";
 export type { SchemaInterpreterMap } from "./interpreter-utils";
 export { ZodIntersectionBuilder } from "./intersection";
 export { ZodLiteralBuilder } from "./literal";
+export { ZodMapBuilder, ZodSetBuilder } from "./map-set";
 export { ZodNumberBuilder } from "./number";
 export type { ShapeInput } from "./object";
 export { ZodObjectBuilder } from "./object";
@@ -82,6 +85,7 @@ export interface ZodNamespace
     ZodEnumNamespace,
     ZodIntersectionNamespace,
     ZodLiteralNamespace,
+    ZodMapSetNamespace,
     ZodNumberNamespace,
     ZodObjectNamespace,
     ZodPrimitivesNamespace,
@@ -132,6 +136,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...enumNodeKinds,
     ...intersectionNodeKinds,
     ...literalNodeKinds,
+    ...mapSetNodeKinds,
     ...numberNodeKinds,
     ...objectNodeKinds,
     ...primitivesNodeKinds,
@@ -153,6 +158,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...enumNamespace(ctx, parseError),
         ...intersectionNamespace(ctx, parseError),
         ...literalNamespace(ctx),
+        ...mapSetNamespace(ctx, parseError),
         ...numberNamespace(ctx, parseError),
         ...objectNamespace(ctx, parseError),
         ...primitivesNamespace(ctx, parseError),

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -9,6 +9,7 @@ import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { toZodError } from "./interpreter-utils";
 import { createIntersectionInterpreter } from "./intersection";
 import { literalInterpreter } from "./literal";
+import { createMapSetInterpreter } from "./map-set";
 import { numberInterpreter } from "./number";
 import { createObjectInterpreter } from "./object";
 import { primitivesInterpreter } from "./primitives";
@@ -32,7 +33,7 @@ const leafHandlers: SchemaInterpreterMap = {
   ...primitivesInterpreter,
 };
 
-// Recursive handlers (array, object, union, intersection, record) need buildSchemaGen for inner schemas.
+// Recursive handlers (array, object, union, intersection, record, map, set) need buildSchemaGen for inner schemas.
 // Initialized lazily on first use to break the definition-order cycle.
 let schemaHandlers: SchemaInterpreterMap | undefined;
 
@@ -46,6 +47,7 @@ function getHandlers(): SchemaInterpreterMap {
       ...createUnionInterpreter(buildSchemaGen),
       ...createIntersectionInterpreter(buildSchemaGen),
       ...createRecordInterpreter(buildSchemaGen),
+      ...createMapSetInterpreter(buildSchemaGen),
     };
   }
   return schemaHandlers;

--- a/packages/plugin-zod/src/map-set.ts
+++ b/packages/plugin-zod/src/map-set.ts
@@ -1,0 +1,187 @@
+import type { ASTNode, PluginContext, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import { checkErrorOpt, toZodError } from "./interpreter-utils";
+import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+
+/**
+ * Builder for Zod map schemas.
+ *
+ * Stores key and value schemas as AST nodes in extra fields.
+ *
+ * @typeParam K - The key type
+ * @typeParam V - The value type
+ */
+export class ZodMapBuilder<K, V> extends ZodSchemaBuilder<Map<K, V>> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/map", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodMapBuilder<K, V> {
+    return new ZodMapBuilder<K, V>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/**
+ * Builder for Zod set schemas with size constraints.
+ *
+ * Stores value schema as AST node in extra field.
+ * Provides min, max, and size check methods.
+ *
+ * @typeParam T - The element type
+ */
+export class ZodSetBuilder<T> extends ZodSchemaBuilder<Set<T>> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/set", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodSetBuilder<T> {
+    return new ZodSetBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+
+  /** Require at least `value` elements. */
+  min(value: number, opts?: { error?: string }): ZodSetBuilder<T> {
+    return this._addCheck("min_size", { value }, opts) as ZodSetBuilder<T>;
+  }
+
+  /** Require at most `value` elements. */
+  max(value: number, opts?: { error?: string }): ZodSetBuilder<T> {
+    return this._addCheck("max_size", { value }, opts) as ZodSetBuilder<T>;
+  }
+
+  /** Require exactly `value` elements. */
+  size(value: number, opts?: { error?: string }): ZodSetBuilder<T> {
+    return this._addCheck("size", { value }, opts) as ZodSetBuilder<T>;
+  }
+}
+
+/** Node kinds contributed by the map/set schemas. */
+export const mapSetNodeKinds: string[] = ["zod/map", "zod/set"];
+
+/**
+ * Namespace fragment for map and set schema factories.
+ */
+export interface ZodMapSetNamespace {
+  /** Create a map schema builder. */
+  map<K, V>(
+    keySchema: ZodSchemaBuilder<K>,
+    valueSchema: ZodSchemaBuilder<V>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodMapBuilder<K, V>;
+
+  /** Create a set schema builder with optional size constraints. */
+  set<T>(
+    valueSchema: ZodSchemaBuilder<T>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodSetBuilder<T>;
+}
+
+/** Build the map/set namespace factory methods. */
+export function mapSetNamespace(
+  ctx: PluginContext,
+  parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodMapSetNamespace {
+  return {
+    map<K, V>(
+      keySchema: ZodSchemaBuilder<K>,
+      valueSchema: ZodSchemaBuilder<V>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodMapBuilder<K, V> {
+      const error = parseError(errorOrOpts);
+      return new ZodMapBuilder<K, V>(ctx, [], [], error, {
+        key: keySchema.__schemaNode,
+        value: valueSchema.__schemaNode,
+      });
+    },
+
+    set<T>(
+      valueSchema: ZodSchemaBuilder<T>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodSetBuilder<T> {
+      const error = parseError(errorOrOpts);
+      return new ZodSetBuilder<T>(ctx, [], [], error, {
+        value: valueSchema.__schemaNode,
+      });
+    },
+  };
+}
+
+/**
+ * Build a Zod schema from a field's AST node by delegating to the
+ * interpreter's buildSchemaGen. This is passed in at registration time
+ * to avoid circular imports.
+ */
+type SchemaBuildFn = (node: ASTNode) => Generator<StepEffect, z.ZodType, unknown>;
+
+/** Create map/set interpreter handlers with access to the shared schema builder. */
+export function createMapSetInterpreter(buildSchema: SchemaBuildFn): SchemaInterpreterMap {
+  return {
+    "zod/map": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+      const keySchema = yield* buildSchema(node.key as ASTNode);
+      const valueSchema = yield* buildSchema(node.value as ASTNode);
+      const errorFn = toZodError(node.error as ErrorConfig | undefined);
+      const errOpt = errorFn ? { error: errorFn } : {};
+      return z.map(keySchema as z.ZodString, valueSchema, errOpt);
+    },
+
+    "zod/set": function* (node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+      const valueSchema = yield* buildSchema(node.value as ASTNode);
+      const checks = (node.checks as CheckDescriptor[]) ?? [];
+      const errorFn = toZodError(node.error as ErrorConfig | undefined);
+      const errOpt = errorFn ? { error: errorFn } : {};
+      let s = z.set(valueSchema, errOpt);
+      for (const check of checks) {
+        const cErr = checkErrorOpt(check);
+        switch (check.kind) {
+          case "min_size":
+            s = s.min(check.value as number, cErr);
+            break;
+          case "max_size":
+            s = s.max(check.value as number, cErr);
+            break;
+          case "size":
+            s = s.size(check.value as number, cErr);
+            break;
+          default:
+            throw new Error(`Zod interpreter: unknown set check "${check.kind}"`);
+        }
+      }
+      return s;
+    },
+  };
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -2,9 +2,11 @@ import { mvfm } from "@mvfm/core";
 import { describe, expect, it } from "vitest";
 import {
   ZodIntersectionBuilder,
+  ZodMapBuilder,
   ZodNumberBuilder,
   ZodPrimitiveBuilder,
   ZodRecordBuilder,
+  ZodSetBuilder,
   ZodStringBuilder,
   ZodTupleBuilder,
   ZodUnionBuilder,
@@ -969,5 +971,75 @@ describe("record schemas (#115)", () => {
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.kind).toBe("zod/optional");
     expect(ast.result.schema.inner.kind).toBe("zod/record");
+  });
+});
+describe("map/set schemas (#116)", () => {
+  it("$.zod.map() returns a ZodMapBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.map($.zod.string(), $.zod.string());
+      expect(builder).toBeInstanceOf(ZodMapBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.map() produces zod/map AST with key and value schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.map($.zod.string(), $.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/map");
+    expect(ast.result.schema.key.kind).toBe("zod/string");
+    expect(ast.result.schema.value.kind).toBe("zod/string");
+  });
+
+  it("$.zod.set() returns a ZodSetBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.set($.zod.string());
+      expect(builder).toBeInstanceOf(ZodSetBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.set() produces zod/set AST with value schema", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.set($.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/set");
+    expect(ast.result.schema.value.kind).toBe("zod/string");
+  });
+
+  it("set size checks chain correctly", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.set($.zod.string()).min(2).max(5).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.checks).toHaveLength(2);
+    expect(ast.result.schema.checks[0]).toMatchObject({ kind: "min_size", value: 2 });
+    expect(ast.result.schema.checks[1]).toMatchObject({ kind: "max_size", value: 5 });
+  });
+
+  it("set size() adds exact size check", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.set($.zod.string()).size(3).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.checks[0]).toMatchObject({ kind: "size", value: 3 });
+  });
+
+  it("wrappers work on map/set schemas", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.set($.zod.string()).optional().parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/set");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -893,3 +893,64 @@ describe("zodInterpreter: record schemas (#152)", () => {
     expect(valid.success).toBe(true);
   });
 });
+describe("zodInterpreter: map/set schemas (#153)", () => {
+  it("map accepts valid Map input", async () => {
+    const prog = app(($) => $.zod.map($.zod.string(), $.zod.string()).parse($.input.value));
+    const m = new Map([["a", "hello"]]);
+    const result = await run(prog, { value: m });
+    expect(result).toBeInstanceOf(Map);
+    expect((result as Map<string, string>).get("a")).toBe("hello");
+  });
+
+  it("map rejects non-Map input", async () => {
+    const prog = app(($) => $.zod.map($.zod.string(), $.zod.string()).safeParse($.input.value));
+    const result = (await run(prog, { value: "not a map" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("set accepts valid Set input", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).parse($.input.value));
+    const s = new Set(["a", "b"]);
+    const result = await run(prog, { value: s });
+    expect(result).toBeInstanceOf(Set);
+    expect((result as Set<string>).has("a")).toBe(true);
+  });
+
+  it("set rejects non-Set input", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).safeParse($.input.value));
+    const result = (await run(prog, { value: "not a set" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("set min() rejects too-small sets", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).min(3).safeParse($.input.value));
+    const result = (await run(prog, { value: new Set(["a"]) })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("set min() accepts large enough sets", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).min(2).safeParse($.input.value));
+    const result = (await run(prog, { value: new Set(["a", "b"]) })) as any;
+    expect(result.success).toBe(true);
+  });
+
+  it("set max() rejects too-large sets", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).max(2).safeParse($.input.value));
+    const result = (await run(prog, { value: new Set(["a", "b", "c"]) })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("set size() rejects wrong-sized sets", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).size(2).safeParse($.input.value));
+    const small = (await run(prog, { value: new Set(["a"]) })) as any;
+    const exact = (await run(prog, { value: new Set(["a", "b"]) })) as any;
+    expect(small.success).toBe(false);
+    expect(exact.success).toBe(true);
+  });
+
+  it("optional set works", async () => {
+    const prog = app(($) => $.zod.set($.zod.string()).optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    expect(undef.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #116
Closes #153

## What this does
Implements `$.zod.map(key, value)` and `$.zod.set(value)` with `min_size`, `max_size`, and `size` check descriptors on sets. The interpreter constructs `z.map()` and `z.set()` with size constraints applied via check methods.

## Design alignment
- **Immutable chaining**: Both builders return new instances via `_clone()`
- **AST determinism**: Key/value stored as AST nodes, checks as descriptors
- **Plugin namespace**: `zod/map` and `zod/set` registered in `nodeKinds`

## Validation performed
- `pnpm run -r build` — all packages compile cleanly
- `npx biome check` — lint/format pass
- `npx vitest run packages/plugin-zod` — 91 tests pass (43 AST + 48 interpreter)
- New tests: 7 AST tests + 9 interpreter round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)