### PR TITLE
feat(plugin-zod): transform, pipe, and preprocess (#118, #155)

### DIFF
--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -27,6 +27,8 @@ import type { ZodStringNamespace } from "./string";
 import { stringNamespace, stringNodeKinds } from "./string";
 import type { ZodStringFormatsNamespace } from "./string-formats";
 import { stringFormatsNamespace, stringFormatsNodeKinds } from "./string-formats";
+import type { ZodTransformNamespace } from "./transform";
+import { transformNamespace, transformNodeKinds } from "./transform";
 import type { ZodTupleNamespace } from "./tuple";
 import { tupleNamespace, tupleNodeKinds } from "./tuple";
 import type { ZodUnionNamespace } from "./union";
@@ -51,6 +53,7 @@ export { ZodRecordBuilder } from "./record";
 export { ZodStringBuilder } from "./string";
 export type { ZodIsoNamespace, ZodStringFormatsNamespace } from "./string-formats";
 export { buildStringFormat } from "./string-formats";
+export { ZodTransformBuilder } from "./transform";
 export { ZodTupleBuilder } from "./tuple";
 export type {
   CheckDescriptor,
@@ -91,6 +94,7 @@ export interface ZodNamespace
     ZodPrimitivesNamespace,
     ZodRecordNamespace,
     ZodStringFormatsNamespace,
+    ZodTransformNamespace,
     ZodTupleNamespace,
     ZodUnionNamespace {
   /** Coercion constructors -- convert input before validating. */
@@ -143,6 +147,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...coerceNodeKinds,
     ...recordNodeKinds,
     ...stringFormatsNodeKinds,
+    ...transformNodeKinds,
     ...tupleNodeKinds,
     ...unionNodeKinds,
     // ^^^ Each new schema type adds ONE spread here
@@ -165,6 +170,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...coerceNamespace(ctx, parseError),
         ...recordNamespace(ctx, parseError),
         ...stringFormatsNamespace(ctx, parseError),
+        ...transformNamespace(ctx),
         ...tupleNamespace(ctx, parseError),
         ...unionNamespace(ctx, parseError),
         // ^^^ Each new schema type adds ONE spread here

--- a/packages/plugin-zod/src/transform.ts
+++ b/packages/plugin-zod/src/transform.ts
@@ -1,0 +1,106 @@
+import type { ASTNode, Expr, PluginContext } from "@mvfm/core";
+import { ZodSchemaBuilder, ZodWrappedBuilder } from "./base";
+import type { CheckDescriptor, ErrorConfig, RefinementDescriptor, WrapperASTNode } from "./types";
+
+/**
+ * Builder for standalone Zod transform schemas.
+ *
+ * Represents a transform that accepts any input and produces a typed output.
+ * Used for `$.zod.transform(fn)`.
+ *
+ * @typeParam T - The output type
+ */
+export class ZodTransformBuilder<T> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/transform", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodTransformBuilder<T> {
+    return new ZodTransformBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/**
+ * Build a standalone transform. Creates a lambda from the callback.
+ */
+export function buildStandaloneTransform<T>(
+  ctx: PluginContext,
+  fn: (val: Expr<unknown>) => Expr<T>,
+): ZodTransformBuilder<T> {
+  const paramNode: ASTNode = { kind: "core/lambda_param", name: "transform_val" };
+  const paramProxy = ctx.expr<unknown>(paramNode);
+  const result = fn(paramProxy);
+  const bodyNode = ctx.isExpr(result) ? result.__node : paramNode;
+  return new ZodTransformBuilder<T>(ctx, [], [], undefined, {
+    fn: { kind: "core/lambda", param: paramNode, body: bodyNode },
+  });
+}
+
+/**
+ * Build a preprocess node. Creates a lambda from the callback and wraps the target schema.
+ */
+export function buildPreprocess<T>(
+  ctx: PluginContext,
+  fn: (val: Expr<unknown>) => Expr<unknown>,
+  schema: ZodSchemaBuilder<T>,
+): ZodWrappedBuilder<T> {
+  const paramNode: ASTNode = { kind: "core/lambda_param", name: "preprocess_val" };
+  const paramProxy = ctx.expr<unknown>(paramNode);
+  const result = fn(paramProxy);
+  const bodyNode = ctx.isExpr(result) ? result.__node : paramNode;
+  const wrapperNode: WrapperASTNode = {
+    kind: "zod/preprocess",
+    inner: schema.__schemaNode,
+    fn: { kind: "core/lambda", param: paramNode, body: bodyNode },
+  };
+  return new ZodWrappedBuilder<T>(ctx, wrapperNode);
+}
+
+/** Node kinds contributed by the transform/pipe/preprocess module. */
+export const transformNodeKinds: string[] = ["zod/transform", "zod/pipe", "zod/preprocess"];
+
+/**
+ * Namespace fragment for transform, pipe, and preprocess factories.
+ */
+export interface ZodTransformNamespace {
+  /** Create a standalone transform that accepts any input and produces typed output. */
+  transform<T>(fn: (val: Expr<unknown>) => Expr<T>): ZodTransformBuilder<T>;
+
+  /** Create a preprocess wrapper that transforms input before validating with the given schema. */
+  preprocess<T>(
+    fn: (val: Expr<unknown>) => Expr<unknown>,
+    schema: ZodSchemaBuilder<T>,
+  ): ZodWrappedBuilder<T>;
+}
+
+/** Build the transform namespace factory methods. */
+export function transformNamespace(ctx: PluginContext): ZodTransformNamespace {
+  return {
+    transform<T>(fn: (val: Expr<unknown>) => Expr<T>): ZodTransformBuilder<T> {
+      return buildStandaloneTransform(ctx, fn);
+    },
+    preprocess<T>(
+      fn: (val: Expr<unknown>) => Expr<unknown>,
+      schema: ZodSchemaBuilder<T>,
+    ): ZodWrappedBuilder<T> {
+      return buildPreprocess(ctx, fn, schema);
+    },
+  };
+}

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -8,6 +8,7 @@ import {
   ZodRecordBuilder,
   ZodSetBuilder,
   ZodStringBuilder,
+  ZodTransformBuilder,
   ZodTupleBuilder,
   ZodUnionBuilder,
   ZodWrappedBuilder,
@@ -1041,5 +1042,109 @@ describe("map/set schemas (#116)", () => {
     const ast = strip(prog.ast) as any;
     expect(ast.result.schema.kind).toBe("zod/optional");
     expect(ast.result.schema.inner.kind).toBe("zod/set");
+  });
+});
+
+describe("transform/pipe/preprocess methods (#118)", () => {
+  it(".transform(fn) produces zod/transform wrapper with lambda", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod
+        .string()
+        .transform((val) => val)
+        .parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/transform");
+    expect(ast.result.schema.inner.kind).toBe("zod/string");
+    expect(ast.result.schema.fn.kind).toBe("core/lambda");
+    expect(ast.result.schema.fn.param.kind).toBe("core/lambda_param");
+    expect(ast.result.schema.fn.param.name).toBe("transform_val");
+  });
+
+  it(".transform(fn) returns ZodWrappedBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const wrapped = $.zod.string().transform((val) => val);
+      expect(wrapped).toBeInstanceOf(ZodWrappedBuilder);
+      return wrapped.parse($.input);
+    });
+  });
+
+  it(".pipe(target) produces zod/pipe wrapper with target schema", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.string().pipe($.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/pipe");
+    expect(ast.result.schema.inner.kind).toBe("zod/string");
+    expect(ast.result.schema.target.kind).toBe("zod/string");
+  });
+
+  it("$.zod.transform(fn) produces standalone transform AST", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.transform((val) => val).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/transform");
+    expect(ast.result.schema.fn.kind).toBe("core/lambda");
+    expect(ast.result.schema.fn.param.name).toBe("transform_val");
+    // Standalone transform has no inner
+    expect(ast.result.schema.inner).toBeUndefined();
+  });
+
+  it("$.zod.transform(fn) returns ZodTransformBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.transform((val) => val);
+      expect(builder).toBeInstanceOf(ZodTransformBuilder);
+      return builder.parse($.input);
+    });
+  });
+
+  it("$.zod.preprocess(fn, schema) produces zod/preprocess wrapper", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod.preprocess((val) => val, $.zod.string()).parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/preprocess");
+    expect(ast.result.schema.inner.kind).toBe("zod/string");
+    expect(ast.result.schema.fn.kind).toBe("core/lambda");
+    expect(ast.result.schema.fn.param.name).toBe("preprocess_val");
+  });
+
+  it("chained transforms nest correctly", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod
+        .string()
+        .transform((val) => val)
+        .transform((val) => val)
+        .parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    // Outer transform wraps inner transform wraps string
+    expect(ast.result.schema.kind).toBe("zod/transform");
+    expect(ast.result.schema.inner.kind).toBe("zod/transform");
+    expect(ast.result.schema.inner.inner.kind).toBe("zod/string");
+  });
+
+  it(".transform(fn) preserves inner schema checks", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => {
+      return $.zod
+        .string()
+        .min(3)
+        .transform((val) => val)
+        .parse($.input);
+    });
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/transform");
+    expect(ast.result.schema.inner.kind).toBe("zod/string");
+    expect(ast.result.schema.inner.checks).toHaveLength(1);
+    expect(ast.result.schema.inner.checks[0].kind).toBe("min_length");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -954,3 +954,113 @@ describe("zodInterpreter: map/set schemas (#153)", () => {
     expect(undef.success).toBe(true);
   });
 });
+
+describe("zodInterpreter: transform/pipe/preprocess (#155)", () => {
+  it(".transform(fn) applies transform after validation", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .transform((val) => $.upper(val))
+        .parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello" })).toBe("HELLO");
+  });
+
+  it(".transform(fn) rejects invalid input before transform runs", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .transform((val) => $.upper(val))
+        .parse($.input.value),
+    );
+    await expect(run(prog, { value: 42 })).rejects.toThrow();
+  });
+
+  it(".transform(fn) with safeParse returns transformed data", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .transform((val) => $.trim(val))
+        .safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: "  hello  " })) as any;
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("hello");
+  });
+
+  it(".transform(fn) with safeParse returns failure for invalid input", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .transform((val) => $.upper(val))
+        .safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: 123 })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("chained transforms execute in order", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .transform((val) => $.trim(val))
+        .transform((val) => $.upper(val))
+        .parse($.input.value),
+    );
+    expect(await run(prog, { value: "  hello  " })).toBe("HELLO");
+  });
+
+  it(".transform(fn) with checks validates before transforming", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .string()
+        .min(3)
+        .transform((val) => $.upper(val))
+        .safeParse($.input.value),
+    );
+    const short = (await run(prog, { value: "hi" })) as any;
+    expect(short.success).toBe(false);
+    const valid = (await run(prog, { value: "hello" })) as any;
+    expect(valid.success).toBe(true);
+    expect(valid.data).toBe("HELLO");
+  });
+
+  it(".pipe(target) validates through both schemas", async () => {
+    const prog = app(($) => $.zod.string().pipe($.zod.string().min(3)).safeParse($.input.value));
+    const short = (await run(prog, { value: "hi" })) as any;
+    expect(short.success).toBe(false);
+    const valid = (await run(prog, { value: "hello" })) as any;
+    expect(valid.success).toBe(true);
+  });
+
+  it("$.zod.transform(fn) standalone transform with parse", async () => {
+    const prog = appWithStr(($) => $.zod.transform((val) => $.upper(val)).parse($.input.value));
+    expect(await run(prog, { value: "hello" })).toBe("HELLO");
+  });
+
+  it("$.zod.transform(fn) standalone accepts any input type", async () => {
+    const prog = app(($) => $.zod.transform((val) => val).parse($.input.value));
+    expect(await run(prog, { value: 42 })).toBe(42);
+    expect(await run(prog, { value: "hello" })).toBe("hello");
+  });
+
+  it("$.zod.preprocess(fn, schema) preprocesses before validation", async () => {
+    const prog = appWithStr(($) =>
+      $.zod.preprocess((val) => $.trim(val), $.zod.string().min(3)).safeParse($.input.value),
+    );
+    // "  hi  " → trimmed to "hi" → min(3) fails
+    const short = (await run(prog, { value: "  hi  " })) as any;
+    expect(short.success).toBe(false);
+    // "  hello  " → trimmed to "hello" → min(3) passes
+    const valid = (await run(prog, { value: "  hello  " })) as any;
+    expect(valid.success).toBe(true);
+    expect(valid.data).toBe("hello");
+  });
+
+  it("$.zod.preprocess(fn, schema) with parse", async () => {
+    const prog = appWithStr(($) =>
+      $.zod.preprocess((val) => $.upper(val), $.zod.string()).parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello" })).toBe("HELLO");
+  });
+});


### PR DESCRIPTION
Closes #118
Closes #155

## What this does

Adds transform, pipe, and preprocess support to the Zod plugin DSL and interpreter. This includes `.transform(fn)` and `.pipe(target)` chaining methods on all schema builders, standalone `$.zod.transform(fn)` and `$.zod.preprocess(fn, schema)` constructors, and full interpreter support for `zod/transform`, `zod/pipe`, and `zod/preprocess` node kinds.

## Design alignment

- **Immutable chaining**: `.transform()` and `.pipe()` return new `ZodWrappedBuilder` instances (no mutation)
- **Lambda AST pattern**: Transform and preprocess callbacks produce `core/lambda` nodes with `core/lambda_param` placeholders, consistent with the refinement pattern from #98
- **Wrapper node pattern**: Transform and pipe use wrapper AST nodes with `inner` field, consistent with optional/nullable wrappers from #99
- **Plugin namespace**: Node kinds are namespaced as `zod/transform`, `zod/pipe`, `zod/preprocess`
- **Interpreter generator pattern**: Uses `evaluateLambda` helper with `injectLambdaParam` + recurse effects, consistent with `applyRefinements`

## Validation performed

- `pnpm run -r build` — passes (all packages compile)
- `npx vitest run packages/plugin-zod` — 94 tests passing (44 AST + 50 interpreter)
- `npx @biomejs/biome check` — no lint/format issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema transformation features: transform(), pipe(), and preprocess(), including standalone transforms and namespace access — transforms run in sequence and affect parse/safeParse results so refinements operate on transformed values.

* **Tests**
  * Added comprehensive tests covering transform/pipe/preprocess sequencing, parse/safeParse interactions, standalone transform/preprocess behavior, and validation order across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->