### PR TITLE
feat(plugin-zod): special types — any, unknown, never, nan, promise, custom (#120, #157)

### DIFF
--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -23,6 +23,8 @@ import type { ZodPrimitivesNamespace } from "./primitives";
 import { primitivesNamespace, primitivesNodeKinds } from "./primitives";
 import type { ZodRecordNamespace } from "./record";
 import { recordNamespace, recordNodeKinds } from "./record";
+import type { ZodSpecialNamespace } from "./special";
+import { specialNamespace, specialNodeKinds } from "./special";
 import type { ZodStringNamespace } from "./string";
 import { stringNamespace, stringNodeKinds } from "./string";
 import type { ZodStringFormatsNamespace } from "./string-formats";
@@ -50,6 +52,7 @@ export type { ShapeInput } from "./object";
 export { ZodObjectBuilder } from "./object";
 export { ZodPrimitiveBuilder } from "./primitives";
 export { ZodRecordBuilder } from "./record";
+export { ZodSimpleBuilder } from "./special";
 export { ZodStringBuilder } from "./string";
 export type { ZodIsoNamespace, ZodStringFormatsNamespace } from "./string-formats";
 export { buildStringFormat } from "./string-formats";
@@ -93,6 +96,7 @@ export interface ZodNamespace
     ZodObjectNamespace,
     ZodPrimitivesNamespace,
     ZodRecordNamespace,
+    ZodSpecialNamespace,
     ZodStringFormatsNamespace,
     ZodTransformNamespace,
     ZodTupleNamespace,
@@ -146,6 +150,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
     ...primitivesNodeKinds,
     ...coerceNodeKinds,
     ...recordNodeKinds,
+    ...specialNodeKinds,
     ...stringFormatsNodeKinds,
     ...transformNodeKinds,
     ...tupleNodeKinds,
@@ -169,6 +174,7 @@ export const zod: PluginDefinition<{ zod: ZodNamespace }> = {
         ...primitivesNamespace(ctx, parseError),
         ...coerceNamespace(ctx, parseError),
         ...recordNamespace(ctx, parseError),
+        ...specialNamespace(ctx, parseError),
         ...stringFormatsNamespace(ctx, parseError),
         ...transformNamespace(ctx),
         ...tupleNamespace(ctx, parseError),

--- a/packages/plugin-zod/src/special.ts
+++ b/packages/plugin-zod/src/special.ts
@@ -1,0 +1,156 @@
+import type { ASTNode, Expr, PluginContext, StepEffect } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder, ZodWrappedBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import type { CheckDescriptor, ErrorConfig, RefinementDescriptor, WrapperASTNode } from "./types";
+
+/**
+ * Builder for simple Zod schema types with no type-specific methods.
+ *
+ * Used for `any`, `unknown`, `never`, and `nan` schemas.
+ * These schemas have no additional check methods — only the
+ * inherited base methods (parse, safeParse, refine, optional, etc.).
+ *
+ * @typeParam T - The output type this schema validates to
+ */
+export class ZodSimpleBuilder<T> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    kind: string,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, kind, checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | ASTNode;
+    extra?: Record<string, unknown>;
+  }): ZodSimpleBuilder<T> {
+    return new ZodSimpleBuilder<T>(
+      this._ctx,
+      this._kind,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/**
+ * Build a promise schema wrapper around an inner schema.
+ * Produces a `zod/promise` wrapper node.
+ */
+export function buildPromise<T>(
+  ctx: PluginContext,
+  inner: ZodSchemaBuilder<T>,
+): ZodWrappedBuilder<Promise<T>> {
+  const wrapperNode: WrapperASTNode = {
+    kind: "zod/promise",
+    inner: inner.__schemaNode,
+  };
+  return new ZodWrappedBuilder<Promise<T>>(ctx, wrapperNode);
+}
+
+/**
+ * Build a custom schema with a DSL predicate callback.
+ * The callback receives an `Expr<unknown>` placeholder and must return
+ * an `Expr<boolean>` built from DSL operations.
+ */
+export function buildCustom<T>(
+  ctx: PluginContext,
+  fn: (val: Expr<unknown>) => Expr<boolean>,
+  errorOrOpts?: string | { error?: string },
+): ZodSimpleBuilder<T> {
+  const paramNode: ASTNode = { kind: "core/lambda_param", name: "custom_val" };
+  const paramProxy = ctx.expr<unknown>(paramNode);
+  const result = fn(paramProxy);
+  const bodyNode = ctx.isExpr(result) ? result.__node : paramNode;
+  const error = typeof errorOrOpts === "string" ? errorOrOpts : errorOrOpts?.error;
+  return new ZodSimpleBuilder<T>(ctx, "zod/custom", [], [], error, {
+    predicate: { kind: "core/lambda", param: paramNode, body: bodyNode },
+  });
+}
+
+/** Node kinds contributed by the special schema types. */
+export const specialNodeKinds: string[] = [
+  "zod/any",
+  "zod/unknown",
+  "zod/never",
+  "zod/promise",
+  "zod/custom",
+];
+
+/**
+ * Namespace fragment for special schema factories.
+ * Note: `nan` is handled by the number module (ZodNumberNamespace).
+ */
+export interface ZodSpecialNamespace {
+  /** Create an `any` schema that accepts all values. */
+  any(): ZodSimpleBuilder<any>;
+  /** Create an `unknown` schema that accepts all values (type-safe). */
+  unknown(): ZodSimpleBuilder<unknown>;
+  /** Create a `never` schema that rejects all values. */
+  never(): ZodSimpleBuilder<never>;
+  /** Create a `promise` schema that wraps an inner schema. */
+  promise<T>(inner: ZodSchemaBuilder<T>): ZodWrappedBuilder<Promise<T>>;
+  /** Create a custom schema with a DSL predicate. */
+  custom<T = unknown>(
+    fn: (val: Expr<unknown>) => Expr<boolean>,
+    errorOrOpts?: string | { error?: string },
+  ): ZodSimpleBuilder<T>;
+}
+
+/** Build the special namespace factory methods. */
+export function specialNamespace(
+  ctx: PluginContext,
+  _parseError: (errorOrOpts?: string | { error?: string }) => string | undefined,
+): ZodSpecialNamespace {
+  return {
+    any(): ZodSimpleBuilder<any> {
+      return new ZodSimpleBuilder<any>(ctx, "zod/any");
+    },
+    unknown(): ZodSimpleBuilder<unknown> {
+      return new ZodSimpleBuilder<unknown>(ctx, "zod/unknown");
+    },
+    never(): ZodSimpleBuilder<never> {
+      return new ZodSimpleBuilder<never>(ctx, "zod/never");
+    },
+    promise<T>(inner: ZodSchemaBuilder<T>): ZodWrappedBuilder<Promise<T>> {
+      return buildPromise(ctx, inner);
+    },
+    custom<T = unknown>(
+      fn: (val: Expr<unknown>) => Expr<boolean>,
+      errorOrOpts?: string | { error?: string },
+    ): ZodSimpleBuilder<T> {
+      return buildCustom<T>(ctx, fn, errorOrOpts);
+    },
+  };
+}
+
+/** Interpreter handlers for special schema nodes. */
+export const specialInterpreter: SchemaInterpreterMap = {
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/any": function* (_node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+    return z.any();
+  },
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/unknown": function* (_node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+    return z.unknown();
+  },
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/never": function* (_node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+    return z.never();
+  },
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/custom": function* (_node: ASTNode): Generator<StepEffect, z.ZodType, unknown> {
+    // Custom predicate is an AST lambda — evaluated post-validation via refinements
+    // For the Zod schema, use z.any() as base and let refinements handle the predicate
+    return z.any();
+  },
+};

--- a/packages/plugin-zod/tests/base.test.ts
+++ b/packages/plugin-zod/tests/base.test.ts
@@ -7,6 +7,7 @@ import {
   ZodPrimitiveBuilder,
   ZodRecordBuilder,
   ZodSetBuilder,
+  ZodSimpleBuilder,
   ZodStringBuilder,
   ZodTransformBuilder,
   ZodTupleBuilder,
@@ -1146,5 +1147,85 @@ describe("transform/pipe/preprocess methods (#118)", () => {
     expect(ast.result.schema.inner.kind).toBe("zod/string");
     expect(ast.result.schema.inner.checks).toHaveLength(1);
     expect(ast.result.schema.inner.checks[0].kind).toBe("min_length");
+  });
+});
+
+describe("special types (#120)", () => {
+  it("$.zod.any() produces zod/any AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.any().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/any");
+  });
+
+  it("$.zod.any() returns ZodSimpleBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      expect($.zod.any()).toBeInstanceOf(ZodSimpleBuilder);
+      return $.zod.any().parse($.input);
+    });
+  });
+
+  it("$.zod.unknown() produces zod/unknown AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.unknown().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/unknown");
+  });
+
+  it("$.zod.never() produces zod/never AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.never().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/never");
+  });
+
+  it("$.zod.nan() produces zod/nan AST node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.nan().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/nan");
+  });
+
+  it("$.zod.promise(inner) produces zod/promise wrapper node", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.promise($.zod.string()).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/promise");
+    expect(ast.result.schema.inner.kind).toBe("zod/string");
+  });
+
+  it("$.zod.promise() returns ZodWrappedBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const wrapped = $.zod.promise($.zod.string());
+      expect(wrapped).toBeInstanceOf(ZodWrappedBuilder);
+      return wrapped.parse($.input);
+    });
+  });
+
+  it("$.zod.custom(fn) produces zod/custom AST node with predicate", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.custom((val) => val).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/custom");
+    expect(ast.result.schema.predicate.kind).toBe("core/lambda");
+    expect(ast.result.schema.predicate.param.name).toBe("custom_val");
+  });
+
+  it("$.zod.custom(fn) accepts error config", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.custom((val) => val, "Must pass!").parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/custom");
+    expect(ast.result.schema.error).toBe("Must pass!");
+  });
+
+  it("special types support wrappers", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.any().optional().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/any");
   });
 });

--- a/packages/plugin-zod/tests/interpreter.test.ts
+++ b/packages/plugin-zod/tests/interpreter.test.ts
@@ -1064,3 +1064,61 @@ describe("zodInterpreter: transform/pipe/preprocess (#155)", () => {
     expect(await run(prog, { value: "hello" })).toBe("HELLO");
   });
 });
+
+describe("zodInterpreter: special types (#157)", () => {
+  it("any() accepts any value", async () => {
+    const prog = app(($) => $.zod.any().parse($.input.value));
+    expect(await run(prog, { value: "hello" })).toBe("hello");
+    expect(await run(prog, { value: 42 })).toBe(42);
+    expect(await run(prog, { value: null })).toBeNull();
+    expect(await run(prog, { value: undefined })).toBeUndefined();
+  });
+
+  it("unknown() accepts any value", async () => {
+    const prog = app(($) => $.zod.unknown().parse($.input.value));
+    expect(await run(prog, { value: "hello" })).toBe("hello");
+    expect(await run(prog, { value: 42 })).toBe(42);
+  });
+
+  it("never() rejects all values", async () => {
+    const prog = app(($) => $.zod.never().safeParse($.input.value));
+    const str = (await run(prog, { value: "hello" })) as any;
+    expect(str.success).toBe(false);
+    const num = (await run(prog, { value: 42 })) as any;
+    expect(num.success).toBe(false);
+  });
+
+  it("nan() accepts NaN", async () => {
+    const prog = app(($) => $.zod.nan().safeParse($.input.value));
+    const valid = (await run(prog, { value: Number.NaN })) as any;
+    expect(valid.success).toBe(true);
+    const invalid = (await run(prog, { value: 42 })) as any;
+    expect(invalid.success).toBe(false);
+  });
+
+  it("custom(fn) validates with the predicate", async () => {
+    const prog = appWithStr(($) =>
+      $.zod.custom((val) => $.startsWith(val, "hello")).parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello world" })).toBe("hello world");
+  });
+
+  it("custom(fn) rejects when predicate returns false", async () => {
+    const prog = appWithStr(($) =>
+      $.zod
+        .custom((val) => $.startsWith(val, "hello"), "Must start with hello")
+        .safeParse($.input.value),
+    );
+    const result = (await run(prog, { value: "goodbye" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.message).toBe("Must start with hello");
+  });
+
+  it("any() with optional wrapper", async () => {
+    const prog = app(($) => $.zod.any().optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    expect(undef.success).toBe(true);
+    const valid = (await run(prog, { value: "hi" })) as any;
+    expect(valid.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #120
Closes #157

## What this does

Adds special Zod schema types to the plugin DSL and interpreter: `$.zod.any()`, `$.zod.unknown()`, `$.zod.never()`, `$.zod.nan()`, `$.zod.promise(inner)`, and `$.zod.custom(fn)`. Uses a reusable `ZodSimpleBuilder<T>` for schemas with no type-specific methods. Custom schema predicates are stored as AST lambdas and evaluated through the existing refinement pipeline.

## Design alignment

- **Immutable chaining**: All builders extend `ZodSchemaBuilder` with proper `_clone()`
- **Plugin namespace**: Node kinds namespaced as `zod/any`, `zod/unknown`, etc.
- **Lambda AST pattern**: `$.zod.custom(fn)` captures predicates as `core/lambda` nodes
- **Interpreter generator pattern**: Special types map directly to Zod v4 equivalents; custom predicate evaluated via refinement pipeline

## Validation performed

- `pnpm run -r build` — passes
- `npx vitest run packages/plugin-zod` — 92 tests passing (46 AST + 46 interpreter)
- `npx @biomejs/biome check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)