### PR TITLE
refactor(plugin-redis): add typed node interfaces to redis interpreter

### DIFF
--- a/docs/plans/2026-02-16-redis-typed-node-interfaces-design.md
+++ b/docs/plans/2026-02-16-redis-typed-node-interfaces-design.md
@@ -1,0 +1,50 @@
+# Redis Typed Node Interfaces Design
+
+## Context
+Issue `#191` identifies that `packages/plugin-redis/src/5.4.1/interpreter.ts` still has many handler parameters typed as `any`, which defeats the `TypedNode<T>` phantom typing pattern already used across migrated interpreters.
+
+## Goals
+- Define typed node interfaces for all 35 redis node kinds.
+- Replace all `node: any` handler signatures with specific node interfaces.
+- Keep runtime behavior unchanged.
+- Add regression tests for both runtime behavior and compile-time typing guarantees.
+
+## Non-goals
+- No runtime behavior changes.
+- No command surface expansion.
+- No per-command-family file split.
+
+## Design
+### 1. Node typing model
+Introduce concrete per-kind interfaces in the redis interpreter module, grouped by existing sections:
+- String commands
+- Key commands
+- Hash commands
+- List commands
+
+Each interface will:
+- Extend `TypedNode<TReturn>`
+- Pin `kind` to a string literal (e.g. `"redis/hget"`)
+- Type each child field as `TypedNode<...>` or arrays thereof
+- Model optional fields (`args`, `count`) explicitly
+
+Shared structural bases (`key`, `keys`, key+value patterns) remain, but all 35 concrete kinds will have concrete interfaces.
+
+### 2. Interpreter updates
+Update each handler signature to use its concrete interface. Handler internals remain equivalent, only type-safe field access replaces `any` assumptions.
+
+### 3. Type regression coverage
+Add type-level assertions using `expectTypeOf` and targeted `@ts-expect-error` checks in plugin redis tests to ensure command nodes are correctly typed and invalid field access on typed nodes is rejected.
+
+### 4. Runtime regression coverage
+Keep interpreter command-shape tests and add/adjust focused tests only where needed to ensure no command argument behavior changed.
+
+## Risks and mitigations
+- Risk: incorrect return typing for a node kind.
+- Mitigation: align each interface return type with `packages/plugin-redis/src/5.4.1/index.ts` method signatures and existing test expectations.
+
+## Validation
+- `npm run build`
+- `npm run check`
+- `npm test`
+

--- a/docs/plans/2026-02-16-redis-typed-node-interfaces-plan.md
+++ b/docs/plans/2026-02-16-redis-typed-node-interfaces-plan.md
@@ -1,0 +1,54 @@
+# Redis Typed Node Interfaces Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove `any` from redis interpreter handlers by introducing typed node interfaces for all 35 node kinds, with no runtime behavior changes.
+
+**Architecture:** Keep interpreter behavior unchanged while hardening the type layer. Define concrete node interfaces grouped by command family and update handler signatures to consume these types. Add compile-time and runtime regression tests.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace.
+
+---
+
+### Task 1: Add failing type regression tests
+
+**Files:**
+- Modify: `packages/plugin-redis/tests/5.4.1/index.test.ts`
+
+**Steps:**
+1. Add `expectTypeOf` checks for representative redis command return types (`get`, `set`, `hget`, `lrange`, etc.).
+2. Add `@ts-expect-error` checks for invalid method arguments.
+3. Run plugin-redis tests/checks to ensure type assertions exercise compiler behavior.
+
+### Task 2: Replace `any` handler signatures with concrete per-kind interfaces
+
+**Files:**
+- Modify: `packages/plugin-redis/src/5.4.1/interpreter.ts`
+
+**Steps:**
+1. Define concrete interfaces for all 35 redis kinds grouped by existing section headers.
+2. Keep shared base interfaces for repeated shapes while still defining concrete per-kind interfaces.
+3. Update every handler signature to use its corresponding node interface.
+4. Ensure no `node: any` remains in redis interpreter.
+
+### Task 3: Verify runtime behavior remains stable
+
+**Files:**
+- Modify (if needed): `packages/plugin-redis/tests/5.4.1/interpreter.test.ts`
+
+**Steps:**
+1. Run redis interpreter tests.
+2. Add targeted test adjustments only if type-driven fixes expose missing coverage.
+3. Confirm command names and argument ordering remain unchanged.
+
+### Task 4: Full verification
+
+**Files:**
+- No new files.
+
+**Steps:**
+1. Run `npm run build`.
+2. Run `npm run check`.
+3. Run `npm test`.
+4. Record results for PR validation evidence.
+

--- a/docs/plans/2026-02-16-redis-typed-node-interfaces.md
+++ b/docs/plans/2026-02-16-redis-typed-node-interfaces.md
@@ -1,0 +1,103 @@
+# Redis Typed Node Interfaces Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `node: any` handler signatures in the redis interpreter with specific typed node interfaces for all redis node kinds.
+
+**Architecture:** Keep the existing `createRedisInterpreter` structure and runtime command behavior unchanged. Define and group typed interfaces by command family (strings, keys, hashes, lists), then wire each handler to its corresponding interface so `eval_` calls infer child value types through `TypedNode<T>`.
+
+**Tech Stack:** TypeScript, `@mvfm/core` `TypedNode`/`eval_`, existing redis plugin tests.
+
+---
+
+### Task 1: Add string command node interfaces
+
+**Files:**
+- Modify: `packages/plugin-redis/src/5.4.1/interpreter.ts`
+- Test: `packages/plugin-redis/tests/5.4.1/interpreter.test.ts`
+
+**Step 1: Write failing test**
+
+Add a type-level compile test by replacing one existing string handler signature usage from `any` to a non-`any` typed interface and compile.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run build --workspace @mvfm/plugin-redis`
+Expected: FAIL until all referenced fields are typed consistently.
+
+**Step 3: Write minimal implementation**
+
+Define specific string interfaces and update handlers:
+- `redis/set`, `redis/incrby`, `redis/decrby`, `redis/mset`, `redis/getrange`, `redis/setrange`
+- Reuse existing `RedisKeyNode`, `RedisKeyValueNode`, `RedisKeysNode` where applicable.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run build --workspace @mvfm/plugin-redis`
+Expected: PASS for string interface updates.
+
+**Step 5: Commit**
+
+```bash
+git add packages/plugin-redis/src/5.4.1/interpreter.ts
+git commit -m "refactor(plugin-redis): type string command handler nodes"
+```
+
+### Task 2: Add key/hash/list command node interfaces
+
+**Files:**
+- Modify: `packages/plugin-redis/src/5.4.1/interpreter.ts`
+- Test: `packages/plugin-redis/tests/5.4.1/interpreter.test.ts`
+
+**Step 1: Write failing test**
+
+Continue replacing key/hash/list `any` signatures to typed interfaces and compile.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run build --workspace @mvfm/plugin-redis`
+Expected: FAIL until all handlers reference valid typed interfaces.
+
+**Step 3: Write minimal implementation**
+
+Define remaining interfaces and wire handlers:
+- Key: `redis/expire`, `redis/pexpire`
+- Hash: `redis/hget`, `redis/hset`, `redis/hmget`, `redis/hdel`, `redis/hexists`, `redis/hincrby`
+- List: `redis/lpush`, `redis/rpush`, `redis/lpop`, `redis/rpop`, `redis/lrange`, `redis/lindex`, `redis/lset`, `redis/lrem`, `redis/linsert`
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run build --workspace @mvfm/plugin-redis`
+Expected: PASS with no behavioral changes.
+
+**Step 5: Commit**
+
+```bash
+git add packages/plugin-redis/src/5.4.1/interpreter.ts
+git commit -m "refactor(plugin-redis): type key hash and list handler nodes"
+```
+
+### Task 3: Full verification and readiness
+
+**Files:**
+- Verify: `packages/plugin-redis/src/5.4.1/interpreter.ts`
+- Verify: `packages/plugin-redis/tests/5.4.1/interpreter.test.ts`
+
+**Step 1: Run full project verification**
+
+Run:
+- `npm run build`
+- `npm run check`
+- `npm test`
+
+**Step 2: Confirm no runtime behavior changes**
+
+Run redis plugin tests specifically:
+- `npm test --workspace @mvfm/plugin-redis`
+
+**Step 3: Commit final changes if needed**
+
+```bash
+git add -A
+git commit -m "refactor(plugin-redis): add typed node interfaces to redis interpreter"
+```

--- a/packages/plugin-redis/src/5.4.1/interpreter.ts
+++ b/packages/plugin-redis/src/5.4.1/interpreter.ts
@@ -24,20 +24,161 @@ function flattenRecord(obj: Record<string, unknown>): unknown[] {
   return result;
 }
 
-interface RedisKeyNode extends TypedNode<unknown> {
-  kind: string;
+interface RedisKeyNode<K extends string, T> extends TypedNode<T> {
+  kind: K;
   key: TypedNode<string>;
 }
 
-interface RedisKeyValueNode extends TypedNode<unknown> {
-  kind: string;
-  key: TypedNode<string>;
-  value: TypedNode;
-}
-
-interface RedisKeysNode extends TypedNode<unknown> {
-  kind: string;
+interface RedisKeysNode<K extends string, T> extends TypedNode<T> {
+  kind: K;
   keys: TypedNode<string>[];
+}
+
+interface RedisKeyValueNode<K extends string, T, V> extends TypedNode<T> {
+  kind: K;
+  key: TypedNode<string>;
+  value: TypedNode<V>;
+}
+
+interface RedisHashFieldNode<K extends string, T> extends TypedNode<T> {
+  kind: K;
+  key: TypedNode<string>;
+  field: TypedNode<string>;
+}
+
+interface RedisHashFieldsNode<K extends string, T> extends TypedNode<T> {
+  kind: K;
+  key: TypedNode<string>;
+  fields: TypedNode<string>[];
+}
+
+interface RedisPushNode<K extends string> extends TypedNode<number> {
+  kind: K;
+  key: TypedNode<string>;
+  elements: TypedNode<string | number>[];
+}
+
+interface RedisPopNode<K extends string> extends TypedNode<string | null> {
+  kind: K;
+  key: TypedNode<string>;
+  count?: TypedNode<number>;
+}
+
+// ---- String command nodes ----
+
+interface RedisGetNode extends RedisKeyNode<"redis/get", string | null> {}
+interface RedisSetNode extends TypedNode<string | null> {
+  kind: "redis/set";
+  key: TypedNode<string>;
+  value: TypedNode<string | number>;
+  args?: TypedNode<string | number>[];
+}
+interface RedisIncrNode extends RedisKeyNode<"redis/incr", number> {}
+interface RedisIncrByNode extends TypedNode<number> {
+  kind: "redis/incrby";
+  key: TypedNode<string>;
+  increment: TypedNode<number>;
+}
+interface RedisDecrNode extends RedisKeyNode<"redis/decr", number> {}
+interface RedisDecrByNode extends TypedNode<number> {
+  kind: "redis/decrby";
+  key: TypedNode<string>;
+  decrement: TypedNode<number>;
+}
+interface RedisMGetNode extends RedisKeysNode<"redis/mget", (string | null)[]> {}
+interface RedisMSetNode extends TypedNode<"OK"> {
+  kind: "redis/mset";
+  mapping: TypedNode<Record<string, string | number>>;
+}
+interface RedisAppendNode extends RedisKeyValueNode<"redis/append", number, string | number> {}
+interface RedisGetRangeNode extends TypedNode<string> {
+  kind: "redis/getrange";
+  key: TypedNode<string>;
+  start: TypedNode<number>;
+  end: TypedNode<number>;
+}
+interface RedisSetRangeNode extends TypedNode<number> {
+  kind: "redis/setrange";
+  key: TypedNode<string>;
+  offset: TypedNode<number>;
+  value: TypedNode<string | number>;
+}
+
+// ---- Key command nodes ----
+
+interface RedisDelNode extends RedisKeysNode<"redis/del", number> {}
+interface RedisExistsNode extends RedisKeysNode<"redis/exists", number> {}
+interface RedisExpireNode extends TypedNode<number> {
+  kind: "redis/expire";
+  key: TypedNode<string>;
+  seconds: TypedNode<number>;
+}
+interface RedisPExpireNode extends TypedNode<number> {
+  kind: "redis/pexpire";
+  key: TypedNode<string>;
+  milliseconds: TypedNode<number>;
+}
+interface RedisTTLNode extends RedisKeyNode<"redis/ttl", number> {}
+interface RedisPTTLNode extends RedisKeyNode<"redis/pttl", number> {}
+
+// ---- Hash command nodes ----
+
+interface RedisHGetNode extends RedisHashFieldNode<"redis/hget", string | null> {}
+interface RedisHSetNode extends TypedNode<number> {
+  kind: "redis/hset";
+  key: TypedNode<string>;
+  mapping: TypedNode<Record<string, string | number>>;
+}
+interface RedisHMGetNode extends RedisHashFieldsNode<"redis/hmget", (string | null)[]> {}
+interface RedisHGetAllNode extends RedisKeyNode<"redis/hgetall", Record<string, string>> {}
+interface RedisHDelNode extends RedisHashFieldsNode<"redis/hdel", number> {}
+interface RedisHExistsNode extends RedisHashFieldNode<"redis/hexists", number> {}
+interface RedisHLenNode extends RedisKeyNode<"redis/hlen", number> {}
+interface RedisHKeysNode extends RedisKeyNode<"redis/hkeys", string[]> {}
+interface RedisHValsNode extends RedisKeyNode<"redis/hvals", string[]> {}
+interface RedisHIncrByNode extends TypedNode<number> {
+  kind: "redis/hincrby";
+  key: TypedNode<string>;
+  field: TypedNode<string>;
+  increment: TypedNode<number>;
+}
+
+// ---- List command nodes ----
+
+interface RedisLPushNode extends RedisPushNode<"redis/lpush"> {}
+interface RedisRPushNode extends RedisPushNode<"redis/rpush"> {}
+interface RedisLPopNode extends RedisPopNode<"redis/lpop"> {}
+interface RedisRPopNode extends RedisPopNode<"redis/rpop"> {}
+interface RedisLLenNode extends RedisKeyNode<"redis/llen", number> {}
+interface RedisLRangeNode extends TypedNode<string[]> {
+  kind: "redis/lrange";
+  key: TypedNode<string>;
+  start: TypedNode<number>;
+  stop: TypedNode<number>;
+}
+interface RedisLIndexNode extends TypedNode<string | null> {
+  kind: "redis/lindex";
+  key: TypedNode<string>;
+  index: TypedNode<number>;
+}
+interface RedisLSetNode extends TypedNode<"OK"> {
+  kind: "redis/lset";
+  key: TypedNode<string>;
+  index: TypedNode<number>;
+  element: TypedNode<string | number>;
+}
+interface RedisLRemNode extends TypedNode<number> {
+  kind: "redis/lrem";
+  key: TypedNode<string>;
+  count: TypedNode<number>;
+  element: TypedNode<string | number>;
+}
+interface RedisLInsertNode extends TypedNode<number> {
+  kind: "redis/linsert";
+  key: TypedNode<string>;
+  position: "BEFORE" | "AFTER";
+  pivot: TypedNode<string | number>;
+  element: TypedNode<string | number>;
 }
 
 /**
@@ -50,12 +191,12 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
   return {
     // ---- String commands ----
 
-    "redis/get": async function* (node: RedisKeyNode) {
+    "redis/get": async function* (node: RedisGetNode) {
       const key = yield* eval_(node.key);
       return await client.command("GET", key);
     },
 
-    "redis/set": async function* (node: any) {
+    "redis/set": async function* (node: RedisSetNode) {
       const key = yield* eval_(node.key);
       const value = yield* eval_(node.value);
       const extra: unknown[] = [];
@@ -65,29 +206,29 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("SET", key, value, ...extra);
     },
 
-    "redis/incr": async function* (node: RedisKeyNode) {
+    "redis/incr": async function* (node: RedisIncrNode) {
       const key = yield* eval_(node.key);
       return await client.command("INCR", key);
     },
 
-    "redis/incrby": async function* (node: any) {
+    "redis/incrby": async function* (node: RedisIncrByNode) {
       const key = yield* eval_(node.key);
       const increment = yield* eval_(node.increment);
       return await client.command("INCRBY", key, increment);
     },
 
-    "redis/decr": async function* (node: RedisKeyNode) {
+    "redis/decr": async function* (node: RedisDecrNode) {
       const key = yield* eval_(node.key);
       return await client.command("DECR", key);
     },
 
-    "redis/decrby": async function* (node: any) {
+    "redis/decrby": async function* (node: RedisDecrByNode) {
       const key = yield* eval_(node.key);
       const decrement = yield* eval_(node.decrement);
       return await client.command("DECRBY", key, decrement);
     },
 
-    "redis/mget": async function* (node: RedisKeysNode) {
+    "redis/mget": async function* (node: RedisMGetNode) {
       const keys: unknown[] = [];
       for (const k of node.keys) {
         keys.push(yield* eval_(k));
@@ -95,25 +236,25 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("MGET", ...keys);
     },
 
-    "redis/mset": async function* (node: any) {
+    "redis/mset": async function* (node: RedisMSetNode) {
       const mapping = (yield* eval_(node.mapping)) as Record<string, unknown>;
       return await client.command("MSET", ...flattenRecord(mapping));
     },
 
-    "redis/append": async function* (node: RedisKeyValueNode) {
+    "redis/append": async function* (node: RedisAppendNode) {
       const key = yield* eval_(node.key);
       const value = yield* eval_(node.value);
       return await client.command("APPEND", key, value);
     },
 
-    "redis/getrange": async function* (node: any) {
+    "redis/getrange": async function* (node: RedisGetRangeNode) {
       const key = yield* eval_(node.key);
       const start = yield* eval_(node.start);
       const end = yield* eval_(node.end);
       return await client.command("GETRANGE", key, start, end);
     },
 
-    "redis/setrange": async function* (node: any) {
+    "redis/setrange": async function* (node: RedisSetRangeNode) {
       const key = yield* eval_(node.key);
       const offset = yield* eval_(node.offset);
       const value = yield* eval_(node.value);
@@ -122,7 +263,7 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
 
     // ---- Key commands ----
 
-    "redis/del": async function* (node: RedisKeysNode) {
+    "redis/del": async function* (node: RedisDelNode) {
       const keys: unknown[] = [];
       for (const k of node.keys) {
         keys.push(yield* eval_(k));
@@ -130,7 +271,7 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("DEL", ...keys);
     },
 
-    "redis/exists": async function* (node: RedisKeysNode) {
+    "redis/exists": async function* (node: RedisExistsNode) {
       const keys: unknown[] = [];
       for (const k of node.keys) {
         keys.push(yield* eval_(k));
@@ -138,43 +279,43 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("EXISTS", ...keys);
     },
 
-    "redis/expire": async function* (node: any) {
+    "redis/expire": async function* (node: RedisExpireNode) {
       const key = yield* eval_(node.key);
       const seconds = yield* eval_(node.seconds);
       return await client.command("EXPIRE", key, seconds);
     },
 
-    "redis/pexpire": async function* (node: any) {
+    "redis/pexpire": async function* (node: RedisPExpireNode) {
       const key = yield* eval_(node.key);
       const ms = yield* eval_(node.milliseconds);
       return await client.command("PEXPIRE", key, ms);
     },
 
-    "redis/ttl": async function* (node: RedisKeyNode) {
+    "redis/ttl": async function* (node: RedisTTLNode) {
       const key = yield* eval_(node.key);
       return await client.command("TTL", key);
     },
 
-    "redis/pttl": async function* (node: RedisKeyNode) {
+    "redis/pttl": async function* (node: RedisPTTLNode) {
       const key = yield* eval_(node.key);
       return await client.command("PTTL", key);
     },
 
     // ---- Hash commands ----
 
-    "redis/hget": async function* (node: any) {
+    "redis/hget": async function* (node: RedisHGetNode) {
       const key = yield* eval_(node.key);
       const field = yield* eval_(node.field);
       return await client.command("HGET", key, field);
     },
 
-    "redis/hset": async function* (node: any) {
+    "redis/hset": async function* (node: RedisHSetNode) {
       const key = yield* eval_(node.key);
       const mapping = (yield* eval_(node.mapping)) as Record<string, unknown>;
       return await client.command("HSET", key, ...flattenRecord(mapping));
     },
 
-    "redis/hmget": async function* (node: any) {
+    "redis/hmget": async function* (node: RedisHMGetNode) {
       const key = yield* eval_(node.key);
       const fields: unknown[] = [];
       for (const f of node.fields) {
@@ -183,12 +324,12 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("HMGET", key, ...fields);
     },
 
-    "redis/hgetall": async function* (node: RedisKeyNode) {
+    "redis/hgetall": async function* (node: RedisHGetAllNode) {
       const key = yield* eval_(node.key);
       return await client.command("HGETALL", key);
     },
 
-    "redis/hdel": async function* (node: any) {
+    "redis/hdel": async function* (node: RedisHDelNode) {
       const key = yield* eval_(node.key);
       const fields: unknown[] = [];
       for (const f of node.fields) {
@@ -197,28 +338,28 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("HDEL", key, ...fields);
     },
 
-    "redis/hexists": async function* (node: any) {
+    "redis/hexists": async function* (node: RedisHExistsNode) {
       const key = yield* eval_(node.key);
       const field = yield* eval_(node.field);
       return await client.command("HEXISTS", key, field);
     },
 
-    "redis/hlen": async function* (node: RedisKeyNode) {
+    "redis/hlen": async function* (node: RedisHLenNode) {
       const key = yield* eval_(node.key);
       return await client.command("HLEN", key);
     },
 
-    "redis/hkeys": async function* (node: RedisKeyNode) {
+    "redis/hkeys": async function* (node: RedisHKeysNode) {
       const key = yield* eval_(node.key);
       return await client.command("HKEYS", key);
     },
 
-    "redis/hvals": async function* (node: RedisKeyNode) {
+    "redis/hvals": async function* (node: RedisHValsNode) {
       const key = yield* eval_(node.key);
       return await client.command("HVALS", key);
     },
 
-    "redis/hincrby": async function* (node: any) {
+    "redis/hincrby": async function* (node: RedisHIncrByNode) {
       const key = yield* eval_(node.key);
       const field = yield* eval_(node.field);
       const increment = yield* eval_(node.increment);
@@ -227,7 +368,7 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
 
     // ---- List commands ----
 
-    "redis/lpush": async function* (node: any) {
+    "redis/lpush": async function* (node: RedisLPushNode) {
       const key = yield* eval_(node.key);
       const elements: unknown[] = [];
       for (const e of node.elements) {
@@ -236,7 +377,7 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("LPUSH", key, ...elements);
     },
 
-    "redis/rpush": async function* (node: any) {
+    "redis/rpush": async function* (node: RedisRPushNode) {
       const key = yield* eval_(node.key);
       const elements: unknown[] = [];
       for (const e of node.elements) {
@@ -245,7 +386,7 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("RPUSH", key, ...elements);
     },
 
-    "redis/lpop": async function* (node: any) {
+    "redis/lpop": async function* (node: RedisLPopNode) {
       const key = yield* eval_(node.key);
       const args: unknown[] = [key];
       if (node.count != null) {
@@ -254,7 +395,7 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("LPOP", ...args);
     },
 
-    "redis/rpop": async function* (node: any) {
+    "redis/rpop": async function* (node: RedisRPopNode) {
       const key = yield* eval_(node.key);
       const args: unknown[] = [key];
       if (node.count != null) {
@@ -263,39 +404,39 @@ export function createRedisInterpreter(client: RedisClient): Interpreter {
       return await client.command("RPOP", ...args);
     },
 
-    "redis/llen": async function* (node: RedisKeyNode) {
+    "redis/llen": async function* (node: RedisLLenNode) {
       const key = yield* eval_(node.key);
       return await client.command("LLEN", key);
     },
 
-    "redis/lrange": async function* (node: any) {
+    "redis/lrange": async function* (node: RedisLRangeNode) {
       const key = yield* eval_(node.key);
       const start = yield* eval_(node.start);
       const stop = yield* eval_(node.stop);
       return await client.command("LRANGE", key, start, stop);
     },
 
-    "redis/lindex": async function* (node: any) {
+    "redis/lindex": async function* (node: RedisLIndexNode) {
       const key = yield* eval_(node.key);
       const index = yield* eval_(node.index);
       return await client.command("LINDEX", key, index);
     },
 
-    "redis/lset": async function* (node: any) {
+    "redis/lset": async function* (node: RedisLSetNode) {
       const key = yield* eval_(node.key);
       const index = yield* eval_(node.index);
       const element = yield* eval_(node.element);
       return await client.command("LSET", key, index, element);
     },
 
-    "redis/lrem": async function* (node: any) {
+    "redis/lrem": async function* (node: RedisLRemNode) {
       const key = yield* eval_(node.key);
       const count = yield* eval_(node.count);
       const element = yield* eval_(node.element);
       return await client.command("LREM", key, count, element);
     },
 
-    "redis/linsert": async function* (node: any) {
+    "redis/linsert": async function* (node: RedisLInsertNode) {
       const key = yield* eval_(node.key);
       const pivot = yield* eval_(node.pivot);
       const element = yield* eval_(node.element);

--- a/packages/plugin-redis/tests/5.4.1/interpreter.test.ts
+++ b/packages/plugin-redis/tests/5.4.1/interpreter.test.ts
@@ -1,9 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { coreInterpreter, foldAST, mvfm, num, str } from "@mvfm/core";
 import { describe, expect, it } from "vitest";
 import { redis } from "../../src/5.4.1";
 import { createRedisInterpreter, type RedisClient } from "../../src/5.4.1/interpreter";
 
 const app = mvfm(num, str, redis({ host: "127.0.0.1", port: 6379 }));
+
+describe("redis interpreter: typing hygiene", () => {
+  it("contains no untyped node:any handler parameters", () => {
+    const source = readFileSync(join(process.cwd(), "src/5.4.1/interpreter.ts"), "utf8");
+    expect(source).not.toMatch(/node:\s*any/);
+  });
+
+  it("contains no broad kind:string node interface fields", () => {
+    const source = readFileSync(join(process.cwd(), "src/5.4.1/interpreter.ts"), "utf8");
+    expect(source).not.toMatch(/kind:\s*string/);
+  });
+});
 
 function injectInput(node: any, input: Record<string, unknown>): any {
   if (node === null || node === undefined || typeof node !== "object") return node;


### PR DESCRIPTION
Closes #191

## What this does
This refactors the redis interpreter to use typed node interfaces for every redis handler instead of broad parameter typing. Each handler now consumes a concrete node type with a literal `kind` and typed child fields, preserving runtime command behavior while improving type safety. It also adds type-focused regression tests for redis API signatures and interpreter typing hygiene.

## Design alignment
No specific VISION.md principles were explicitly cited in #191.
The implementation stays aligned with Phase 1 core solidification goals by strengthening interpreter type correctness without changing runtime semantics.

## Validation performed
- `pnpm --filter @mvfm/plugin-redis run test`
  - Result: PASS (`95` tests)
- `pnpm --filter @mvfm/plugin-redis run check`
  - Result: PASS (biome, tsc, api-extractor)
- `pnpm run build`
  - Result: PASS (core + all plugins)
- `pnpm run check`
  - Result: PASS (core + all plugins)
- `pnpm run test`
  - Result: PASS (all workspace packages)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis commands now feature explicit type definitions across all operations (strings, hashes, lists, keys) with improved IDE support and compile-time safety.
  * Added type-level validation tests ensuring Redis operations preserve correct return types.

* **Tests**
  * Introduced typing regression tests and hygiene validation for Redis command handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->