### PR TITLE
fix(plugin-postgres): type handlers and replace __batchData mutation with closure cell

### DIFF
--- a/packages/plugin-postgres/etc/plugin-postgres.api.json
+++ b/packages/plugin-postgres/etc/plugin-postgres.api.json
@@ -200,7 +200,7 @@
             {
               "kind": "Reference",
               "text": "PostgresQueryNode",
-              "canonicalReference": "@mvfm/plugin-postgres!~PostgresQueryNode:interface"
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresQueryNode:interface"
             },
             {
               "kind": "Content",
@@ -614,51 +614,6 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "@mvfm/plugin-postgres!findCursorBatch:function(1)",
-          "docComment": "/**\n * Find the postgres/cursor_batch node within an AST subtree.\n *\n * The handler uses this to locate the batch data injection point within cursor body expressions.\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export declare function findCursorBatch(node: "
-            },
-            {
-              "kind": "Content",
-              "text": "any"
-            },
-            {
-              "kind": "Content",
-              "text": "): "
-            },
-            {
-              "kind": "Content",
-              "text": "any | null"
-            },
-            {
-              "kind": "Content",
-              "text": ";"
-            }
-          ],
-          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
-          "returnTypeTokenRange": {
-            "startIndex": 3,
-            "endIndex": 4
-          },
-          "releaseTag": "Public",
-          "overloadIndex": 1,
-          "parameters": [
-            {
-              "parameterName": "node",
-              "parameterTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isOptional": false
-            }
-          ],
-          "name": "findCursorBatch"
-        },
-        {
-          "kind": "Function",
           "canonicalReference": "@mvfm/plugin-postgres!postgres:function(1)",
           "docComment": "/**\n * Postgres plugin factory. Namespace: `postgres/`.\n *\n * Creates a plugin that exposes a `sql` tagged template for building parameterized queries, plus helpers for identifiers, inserts, updates, transactions, savepoints, and cursors.\n *\n * @param config - A connection string or {@link PostgresConfig} object.\n *\n * @returns A PluginDefinition for the postgres plugin.\n */\n",
           "excerptTokens": [
@@ -720,6 +675,156 @@
             }
           ],
           "name": "postgres"
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresBeginNode:interface",
+          "docComment": "/**\n * A `postgres/begin` node representing a transaction block.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresBeginNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresBeginNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresBeginNode#body:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "body?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "body",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresBeginNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/begin\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresBeginNode#mode:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "mode: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "mode",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresBeginNode#queries:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "queries?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "queries",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -1337,6 +1442,455 @@
         },
         {
           "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorBatchNode:interface",
+          "docComment": "/**\n * A `postgres/cursor_batch` node — yields the current batch inside a cursor body.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresCursorBatchNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown[]>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresCursorBatchNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorBatchNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/cursor_batch\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorNode:interface",
+          "docComment": "/**\n * A `postgres/cursor` node representing a streaming cursor query.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresCursorNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresCursorNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorNode#batchSize:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "batchSize: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<number>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "batchSize",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorNode#body:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "body: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "body",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/cursor\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresCursorNode#query:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "query: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PostgresQueryNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!PostgresQueryNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "query",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresIdentifierNode:interface",
+          "docComment": "/**\n * A `postgres/identifier` node for dynamic SQL identifiers.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresIdentifierNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<string>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresIdentifierNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresIdentifierNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/identifier\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresIdentifierNode#name:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "name: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "name",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresInsertHelperNode:interface",
+          "docComment": "/**\n * A `postgres/insert_helper` node for bulk INSERT value construction.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresInsertHelperNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<string>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresInsertHelperNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresInsertHelperNode#columns:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "columns?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "columns",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresInsertHelperNode#data:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "data: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown> | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown>[]>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "data",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 7
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresInsertHelperNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/insert_helper\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Interface",
           "canonicalReference": "@mvfm/plugin-postgres!PostgresMethods:interface",
           "docComment": "/**\n * Database operations added to the DSL context by the postgres plugin.\n *\n * Mirrors the postgres.js (porsager/postgres) v3.4.x API as closely as possible: tagged template queries, dynamic identifiers, insert/set helpers, transactions, savepoints, and cursors.\n */\n",
           "excerptTokens": [
@@ -1380,6 +1934,463 @@
             }
           ],
           "extendsTokenRanges": []
+        },
+        {
+          "kind": "TypeAlias",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresParamNode:type",
+          "docComment": "/**\n * Discriminated union of parameter node types within a `postgres/query`.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type PostgresParamNode = "
+            },
+            {
+              "kind": "Reference",
+              "text": "PostgresIdentifierNode",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresIdentifierNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | "
+            },
+            {
+              "kind": "Reference",
+              "text": "PostgresInsertHelperNode",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresInsertHelperNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | "
+            },
+            {
+              "kind": "Reference",
+              "text": "PostgresSetHelperNode",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSetHelperNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresParamNode",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 8
+          }
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresQueryNode:interface",
+          "docComment": "/**\n * A `postgres/query` node representing a parameterized SQL query.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresQueryNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown[]>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresQueryNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresQueryNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/query\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresQueryNode#params:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "params: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PostgresParamNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!PostgresParamNode:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "params",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresQueryNode#strings:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "strings: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "strings",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresSavepointNode:interface",
+          "docComment": "/**\n * A `postgres/savepoint` node representing a savepoint block.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresSavepointNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresSavepointNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSavepointNode#body:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "body?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "body",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSavepointNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/savepoint\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSavepointNode#mode:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "mode: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "mode",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSavepointNode#queries:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "queries?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "queries",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/plugin-postgres!PostgresSetHelperNode:interface",
+          "docComment": "/**\n * A `postgres/set_helper` node for UPDATE SET clause construction.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface PostgresSetHelperNode extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<string>"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/3.4.8/interpreter.d.ts",
+          "releaseTag": "Public",
+          "name": "PostgresSetHelperNode",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSetHelperNode#columns:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "columns?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "columns",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSetHelperNode#data:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "data: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/plugin-postgres!~TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown>>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "data",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/plugin-postgres!PostgresSetHelperNode#kind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "kind: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"postgres/set_helper\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 3
+            }
+          ]
         },
         {
           "kind": "Function",

--- a/packages/plugin-postgres/etc/plugin-postgres.api.md
+++ b/packages/plugin-postgres/etc/plugin-postgres.api.md
@@ -6,7 +6,6 @@
 
 import type { default as postgres_2 } from 'postgres';
 
-// Warning: (ae-forgotten-export) The symbol "PostgresQueryNode" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "TypedNode" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "BuiltQuery" needs to be exported by the entry point index.d.ts
 //
@@ -35,13 +34,22 @@ export function createPostgresServerInterpreter(client: PostgresClient, baseInte
 // @public
 export function escapeIdentifier(name: string): string;
 
-// @public
-export function findCursorBatch(node: any): any | null;
-
 // Warning: (ae-forgotten-export) The symbol "PluginDefinition" needs to be exported by the entry point index.d.ts
 //
 // @public
 export function postgres(config?: PostgresConfig | string): PluginDefinition<PostgresMethods>;
+
+// @public
+export interface PostgresBeginNode extends TypedNode<unknown> {
+    // (undocumented)
+    body?: TypedNode;
+    // (undocumented)
+    kind: "postgres/begin";
+    // (undocumented)
+    mode: string;
+    // (undocumented)
+    queries?: TypedNode[];
+}
 
 // @public
 export interface PostgresClient {
@@ -83,9 +91,80 @@ export interface PostgresConfig {
 }
 
 // @public
+export interface PostgresCursorBatchNode extends TypedNode<unknown[]> {
+    // (undocumented)
+    kind: "postgres/cursor_batch";
+}
+
+// @public
+export interface PostgresCursorNode extends TypedNode<unknown> {
+    // (undocumented)
+    batchSize: TypedNode<number>;
+    // (undocumented)
+    body: TypedNode;
+    // (undocumented)
+    kind: "postgres/cursor";
+    // (undocumented)
+    query: PostgresQueryNode;
+}
+
+// @public
+export interface PostgresIdentifierNode extends TypedNode<string> {
+    // (undocumented)
+    kind: "postgres/identifier";
+    // (undocumented)
+    name: TypedNode<string>;
+}
+
+// @public
+export interface PostgresInsertHelperNode extends TypedNode<string> {
+    // (undocumented)
+    columns?: string[];
+    // (undocumented)
+    data: TypedNode<Record<string, unknown> | Record<string, unknown>[]>;
+    // (undocumented)
+    kind: "postgres/insert_helper";
+}
+
+// @public
 export interface PostgresMethods {
     // Warning: (ae-forgotten-export) The symbol "PostgresSql" needs to be exported by the entry point index.d.ts
     sql: PostgresSql;
+}
+
+// @public
+export type PostgresParamNode = PostgresIdentifierNode | PostgresInsertHelperNode | PostgresSetHelperNode | TypedNode;
+
+// @public
+export interface PostgresQueryNode extends TypedNode<unknown[]> {
+    // (undocumented)
+    kind: "postgres/query";
+    // (undocumented)
+    params: PostgresParamNode[];
+    // (undocumented)
+    strings: string[];
+}
+
+// @public
+export interface PostgresSavepointNode extends TypedNode<unknown> {
+    // (undocumented)
+    body?: TypedNode;
+    // (undocumented)
+    kind: "postgres/savepoint";
+    // (undocumented)
+    mode: string;
+    // (undocumented)
+    queries?: TypedNode[];
+}
+
+// @public
+export interface PostgresSetHelperNode extends TypedNode<string> {
+    // (undocumented)
+    columns?: string[];
+    // (undocumented)
+    data: TypedNode<Record<string, unknown>>;
+    // (undocumented)
+    kind: "postgres/set_helper";
 }
 
 // @public

--- a/packages/plugin-postgres/src/3.4.8/interpreter.ts
+++ b/packages/plugin-postgres/src/3.4.8/interpreter.ts
@@ -29,31 +29,69 @@ interface BuiltQuery {
   params: unknown[];
 }
 
-interface PostgresQueryNode extends TypedNode<unknown[]> {
-  kind: "postgres/query";
-  strings: string[];
-  params: TypedNode[];
+// --- Typed node interfaces -------------------------------------------
+
+/** A `postgres/identifier` node for dynamic SQL identifiers. */
+export interface PostgresIdentifierNode extends TypedNode<string> {
+  kind: "postgres/identifier";
+  name: TypedNode<string>;
 }
 
-interface PostgresBeginNode extends TypedNode<unknown> {
+/** A `postgres/insert_helper` node for bulk INSERT value construction. */
+export interface PostgresInsertHelperNode extends TypedNode<string> {
+  kind: "postgres/insert_helper";
+  data: TypedNode<Record<string, unknown> | Record<string, unknown>[]>;
+  columns?: string[];
+}
+
+/** A `postgres/set_helper` node for UPDATE SET clause construction. */
+export interface PostgresSetHelperNode extends TypedNode<string> {
+  kind: "postgres/set_helper";
+  data: TypedNode<Record<string, unknown>>;
+  columns?: string[];
+}
+
+/** Discriminated union of parameter node types within a `postgres/query`. */
+export type PostgresParamNode =
+  | PostgresIdentifierNode
+  | PostgresInsertHelperNode
+  | PostgresSetHelperNode
+  | TypedNode;
+
+/** A `postgres/query` node representing a parameterized SQL query. */
+export interface PostgresQueryNode extends TypedNode<unknown[]> {
+  kind: "postgres/query";
+  strings: string[];
+  params: PostgresParamNode[];
+}
+
+/** A `postgres/begin` node representing a transaction block. */
+export interface PostgresBeginNode extends TypedNode<unknown> {
   kind: "postgres/begin";
   mode: string;
   body?: TypedNode;
   queries?: TypedNode[];
 }
 
-interface PostgresSavepointNode extends TypedNode<unknown> {
+/** A `postgres/savepoint` node representing a savepoint block. */
+export interface PostgresSavepointNode extends TypedNode<unknown> {
   kind: "postgres/savepoint";
   mode: string;
   body?: TypedNode;
   queries?: TypedNode[];
 }
 
-interface PostgresCursorNode extends TypedNode<unknown> {
+/** A `postgres/cursor` node representing a streaming cursor query. */
+export interface PostgresCursorNode extends TypedNode<unknown> {
   kind: "postgres/cursor";
   query: PostgresQueryNode;
   batchSize: TypedNode<number>;
   body: TypedNode;
+}
+
+/** A `postgres/cursor_batch` node — yields the current batch inside a cursor body. */
+export interface PostgresCursorBatchNode extends TypedNode<unknown[]> {
+  kind: "postgres/cursor_batch";
 }
 
 /**
@@ -71,16 +109,17 @@ export async function* buildSQL(
   for (let i = 0; i < strings.length; i++) {
     sql += strings[i];
     if (i < paramNodes.length) {
-      const param = paramNodes[i] as any;
+      const param = paramNodes[i];
       if (param.kind === "postgres/identifier") {
-        const name = (yield* eval_<string>(param.name)) as string;
+        const id = param as PostgresIdentifierNode;
+        const name = (yield* eval_<string>(id.name)) as string;
         sql += escapeIdentifier(name);
       } else if (param.kind === "postgres/insert_helper") {
-        const data = (yield* eval_(param.data)) as
+        const ins = param as PostgresInsertHelperNode;
+        const data = (yield* eval_(ins.data)) as
           | Record<string, unknown>
           | Record<string, unknown>[];
-        const columns =
-          (param.columns as string[] | null) ?? Object.keys(Array.isArray(data) ? data[0] : data);
+        const columns = ins.columns ?? Object.keys(Array.isArray(data) ? data[0] : data);
         const rows = Array.isArray(data) ? data : [data];
         sql +=
           "(" +
@@ -100,8 +139,9 @@ export async function* buildSQL(
             )
             .join(",");
       } else if (param.kind === "postgres/set_helper") {
-        const data = (yield* eval_(param.data)) as Record<string, unknown>;
-        const columns = (param.columns as string[] | null) ?? Object.keys(data);
+        const set = param as PostgresSetHelperNode;
+        const data = (yield* eval_(set.data)) as Record<string, unknown>;
+        const columns = set.columns ?? Object.keys(data);
         sql += columns
           .map((col) => {
             params.push(data[col]);
@@ -116,31 +156,6 @@ export async function* buildSQL(
   }
 
   return { sql, params };
-}
-
-/**
- * Find the postgres/cursor_batch node within an AST subtree.
- *
- * The handler uses this to locate the batch data injection point
- * within cursor body expressions.
- */
-export function findCursorBatch(node: any): any | null {
-  if (node === null || node === undefined || typeof node !== "object") return null;
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      const found = findCursorBatch(item);
-      if (found) return found;
-    }
-    return null;
-  }
-  if (node.kind === "postgres/cursor_batch") return node;
-  for (const v of Object.values(node)) {
-    if (typeof v === "object" && v !== null) {
-      const found = findCursorBatch(v);
-      if (found) return found;
-    }
-  }
-  return null;
 }
 
 /**
@@ -181,9 +196,11 @@ export function createPostgresInterpreter(client: PostgresClient): Interpreter {
       );
     },
 
-    // biome-ignore lint/correctness/useYield: returns data without needing child evaluation
-    "postgres/cursor_batch": async function* (node: any) {
-      return node.__batchData;
+    // biome-ignore lint/correctness/useYield: stub throws before yielding
+    "postgres/cursor_batch": async function* (_node: PostgresCursorBatchNode) {
+      throw new Error(
+        "postgres/cursor_batch requires the server interpreter — use createPostgresServerInterpreter",
+      );
     },
 
     // biome-ignore lint/correctness/useYield: stub throws before yielding

--- a/packages/plugin-postgres/src/index.ts
+++ b/packages/plugin-postgres/src/index.ts
@@ -8,10 +8,20 @@ export {
   serverEvaluate,
   serverInterpreter,
 } from "./3.4.8/handler.server";
-export type { PostgresClient } from "./3.4.8/interpreter";
+export type {
+  PostgresBeginNode,
+  PostgresClient,
+  PostgresCursorBatchNode,
+  PostgresCursorNode,
+  PostgresIdentifierNode,
+  PostgresInsertHelperNode,
+  PostgresParamNode,
+  PostgresQueryNode,
+  PostgresSavepointNode,
+  PostgresSetHelperNode,
+} from "./3.4.8/interpreter";
 export {
   buildSQL,
   createPostgresInterpreter,
   escapeIdentifier,
-  findCursorBatch,
 } from "./3.4.8/interpreter";


### PR DESCRIPTION
Closes #193
Closes #194

## Summary

- **Typed node interfaces**: Export `PostgresQueryNode`, `PostgresBeginNode`, `PostgresSavepointNode`, `PostgresCursorNode`, `PostgresCursorBatchNode` from `interpreter.ts`. Add new `PostgresIdentifierNode`, `PostgresInsertHelperNode`, `PostgresSetHelperNode` interfaces and `PostgresParamNode` discriminated union for typed dispatch in `buildSQL`. Remove `as any` casts from both `interpreter.ts` and `handler.server.ts`.
- **Closure-cell cursor pattern**: Replace `__batchData` AST mutation with a closure-captured `batchCell` ref. The cursor handler overrides `postgres/cursor_batch` in its interpreter spread, reading from the cell instead of a mutated node property. Removes `findCursorBatch` utility entirely.
- **Base `cursor_batch` handler**: Now throws a clear error if evaluated outside a cursor context (previously returned `undefined` silently).

## Design alignment

- **Typed, immutable nodes** (VISION.md): AST nodes are no longer mutated at runtime. The sole remaining `__batchData` mutation is replaced with a closure cell, making `cursor_batch` the last codebase site that wrote to AST nodes after construction.
- **Interpreter composition via spread** (VISION.md): The cursor handler composes a scoped interpreter by spreading `createPostgresServerInterpreter` and overriding a single handler — no architectural changes needed.

## Validation performed

- `pnpm -r --filter @mvfm/core build` — exit 0
- `pnpm -r --filter @mvfm/plugin-postgres build` — exit 0 (tsc, no type errors)
- `biome check src/` — 0 issues
- `vitest run` — 8/8 test files, 69/69 tests pass
- `api-extractor run --local` — API report regenerated
- Verified: zero `as any` in `interpreter.ts` and `handler.server.ts` (remaining casts are in `client-postgres-js.ts`, out of scope)
- Verified: zero occurrences of `__batchData` or `findCursorBatch` in `src/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Postgres node type interfaces for improved type safety across cursor, query, parameter, and transaction operations.
  * Enhanced Postgres query parameter handling with explicit node types for identifiers, insert helpers, and set helpers.

* **Refactor**
  * Restructured Postgres plugin API with improved type definitions for begin, savepoint, and cursor operations.
  * Removed the `findCursorBatch` function from the public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->