### PR TITLE
feat(core): add scoped recurse for immutable lambda evaluation

### DIFF
--- a/docs/plans/2026-02-16-lambda-scope-spikes-design.md
+++ b/docs/plans/2026-02-16-lambda-scope-spikes-design.md
@@ -1,0 +1,70 @@
+# Lambda Scope Spikes Design Findings
+
+## Context
+Issue #195 asks whether lambda application can become immutable and lexically correct (param identity-based), replacing clone + inject mutation.
+
+## Spike Implementations
+The following three designs were spiked in test-only runtime prototypes:
+
+- `A: recurse_scoped effect`
+  - Evaluator adds an internal scoped recursion effect carrying temporary bindings.
+  - Plugin handlers apply lambdas by yielding `recurse_scoped`.
+- `B: core/apply_lambda node`
+  - Lambda application becomes an explicit core AST node.
+  - Plugins emit/apply that node; evaluator handles node semantics.
+- `C: env-aware contract`
+  - Interpreter contract is env-explicit (`eval(node, env)` model).
+  - Lambda application extends env directly.
+
+Code references:
+- `packages/core/tests/interpreters/lambda-scope-spikes-a-b.ts`
+- `packages/core/tests/interpreters/lambda-scope-spikes-c.ts`
+- `packages/core/tests/interpreters/lambda-scope-spikes.test.ts`
+
+## Correctness Results
+All three spikes passed the same regression scenarios:
+
+1. Lexical shadowing with same param name but different param identities
+2. Repeated lambda invocation over shared body with stable-subnode cache reuse
+3. Error catch-lambda binding semantics
+
+Test command and result:
+- `pnpm --filter @mvfm/core test -- tests/interpreters/lambda-scope-spikes.test.ts`
+- Passed (`9/9` spike tests)
+
+## Comparison
+
+### A: recurse_scoped effect
+- Correctness: Strong
+- Elegance: Good, but introduces a new evaluator-level effect kind
+- Plugin churn: Moderate (only lambda-application callsites)
+- DX impact: Low to moderate; adds one new internal yield pattern
+- Risk: Medium (new effect path in fold/trampoline)
+
+### B: core/apply_lambda node
+- Correctness: Strong
+- Elegance: Medium to high; lambda application is explicit in AST
+- Plugin churn: Moderate (callsites construct `core/apply_lambda`)
+- DX impact: Moderate; adds a new core node kind and docs surface
+- Risk: Medium (core AST surface change)
+
+### C: env-aware contract
+- Correctness: Strong
+- Elegance: Highest (scope is explicit in interpreter model)
+- Plugin churn: High (interpreter contract change across all handlers)
+- DX impact: High (every interpreter author sees the new contract)
+- Risk: High (broad migration and ecosystem disturbance)
+
+## Recommendation
+If priority is architectural elegance + correctness with bounded ecosystem disruption, choose **A (`recurse_scoped`)**.
+
+Rationale:
+- Preserves current plugin contract shape (generator handlers) and avoids global contract migration.
+- Eliminates clone + mutation at lambda-application sites.
+- Achieves lexical correctness with param identity bindings.
+- Keeps blast radius mostly inside fold/core + four known lambda callsites.
+
+If the project is willing to accept broad migration cost for maximal conceptual purity, **C** is the cleanest long-term model.
+
+## Proposed Next Step
+Build a production-grade A implementation in `packages/core/src/fold.ts` + `packages/core/src/interpreters/core.ts`, migrate `fiber/error/zod` callsites, and add regression tests mirroring this spike harness.

--- a/docs/plans/2026-02-16-lambda-scope-spikes-implementation-plan.md
+++ b/docs/plans/2026-02-16-lambda-scope-spikes-implementation-plan.md
@@ -1,0 +1,215 @@
+# Lambda Scope Spikes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build and compare three lexical-scope lambda evaluation spikes (`recurse_scoped` effect, `core/apply_lambda` node, and environment-aware interpreter contract) to choose the cleanest correct architecture.
+
+**Architecture:** All spikes use lexical param identity (`core/lambda_param.__id`) and avoid AST mutation for lambda application. Each spike is implemented behind an explicit runtime variant so behavior is directly comparable from the same AST programs. Comparison is based on correctness (shadowing, reentrancy, memo/taint behavior), plugin impact, and DX ergonomics.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace, mvfm core fold/interpreter architecture.
+
+---
+
+### Task 1: Add cross-cutting lexical-scope regression tests (red)
+
+**Files:**
+- Modify: `packages/core/tests/interpreters/dag-memoization.test.ts`
+- Create: `packages/core/tests/interpreters/lambda-scope-spikes.test.ts`
+
+**Step 1: Write failing tests for lexical correctness invariants**
+
+```ts
+it("does not capture nested lambda with same param name", async () => {
+  // outer param name == inner param name, but node identity differs
+  // expected: inner lambda resolves its own binding only
+});
+
+it("re-evaluates lambda params across invocations without clone", async () => {
+  // same lambda body invoked with different values in one run
+});
+
+it("preserves memoization for stable DAG children under lambda application", async () => {
+  // stable subnode should cache; param-dependent nodes should taint
+});
+```
+
+**Step 2: Run targeted tests to verify they fail**
+
+Run: `pnpm --filter @mvfm/core test -- tests/interpreters/lambda-scope-spikes.test.ts`
+Expected: FAIL (missing runtime support for lexical param scope)
+
+**Step 3: Commit test-only scaffold**
+
+```bash
+git add packages/core/tests/interpreters/lambda-scope-spikes.test.ts packages/core/tests/interpreters/dag-memoization.test.ts
+git commit -m "test(core): add lexical scope regression tests for lambda evaluation (#195)"
+```
+
+### Task 2: Spike A - scoped recurse effect (`recurse_scoped`)
+
+**Files:**
+- Modify: `packages/core/src/fold.ts`
+- Modify: `packages/core/src/interpreters/core.ts`
+- Modify: `packages/core/src/plugins/error/interpreter.ts`
+- Modify: `packages/core/src/plugins/fiber/interpreter.ts`
+- Modify: `packages/plugin-zod/src/interpreter.ts`
+- Test: `packages/core/tests/interpreters/lambda-scope-spikes.test.ts`
+
+**Step 1: Introduce scoped evaluation effect in fold**
+
+```ts
+type ScopedBinding = { paramId: number; value: unknown };
+// child yield variant from handlers:
+// { type: "recurse_scoped", child, bindings }
+```
+
+Add evaluator support that pushes bindings for child evaluation only, then pops on completion/error.
+
+**Step 2: Resolve `core/lambda_param` from fold scope before `__value` fallback**
+
+- Provide a scope lookup helper keyed by `node.__id`.
+- Throw explicit error for unbound lambda param in scoped mode.
+
+**Step 3: Replace clone+inject callsites in fiber/error/zod with scoped recurse**
+
+```ts
+yield { type: "recurse_scoped", child: lambda.body, bindings: [{ paramId: lambda.param.__id, value }] }
+```
+
+**Step 4: Run targeted tests**
+
+Run: `pnpm --filter @mvfm/core test -- tests/interpreters/lambda-scope-spikes.test.ts`
+Expected: PASS for Spike A mode
+
+**Step 5: Commit Spike A**
+
+```bash
+git add packages/core/src/fold.ts packages/core/src/interpreters/core.ts packages/core/src/plugins/error/interpreter.ts packages/core/src/plugins/fiber/interpreter.ts packages/plugin-zod/src/interpreter.ts packages/core/tests/interpreters/lambda-scope-spikes.test.ts
+git commit -m "spike(core): add recurse_scoped lexical lambda evaluation (#195)"
+```
+
+### Task 3: Spike B - explicit `core/apply_lambda` node
+
+**Files:**
+- Modify: `packages/core/src/interpreters/core.ts`
+- Modify: `packages/core/src/plugins/error/interpreter.ts`
+- Modify: `packages/core/src/plugins/fiber/interpreter.ts`
+- Modify: `packages/plugin-zod/src/interpreter.ts`
+- Modify: `packages/core/src/plugins/*/index.ts` (only if builder helper is required)
+- Test: `packages/core/tests/interpreters/lambda-scope-spikes.test.ts`
+
+**Step 1: Add typed node + core interpreter handler**
+
+```ts
+interface CoreApplyLambda extends TypedNode<unknown> {
+  kind: "core/apply_lambda";
+  param: { kind: "core/lambda_param"; __id: number };
+  body: TypedNode;
+  arg: TypedNode;
+}
+```
+
+Handler semantics:
+1. evaluate `arg`
+2. evaluate `body` under lexical binding for `param.__id`
+
+**Step 2: Rewrite lambda application callsites to build/evaluate `core/apply_lambda`**
+
+- Keep existing plugin APIs unchanged.
+- Translate prior clone+inject helpers to node construction.
+
+**Step 3: Run targeted tests**
+
+Run: `pnpm --filter @mvfm/core test -- tests/interpreters/lambda-scope-spikes.test.ts`
+Expected: PASS for Spike B mode
+
+**Step 4: Commit Spike B**
+
+```bash
+git add packages/core/src/interpreters/core.ts packages/core/src/plugins/error/interpreter.ts packages/core/src/plugins/fiber/interpreter.ts packages/plugin-zod/src/interpreter.ts packages/core/tests/interpreters/lambda-scope-spikes.test.ts
+git commit -m "spike(core): model lambda application via core/apply_lambda node (#195)"
+```
+
+### Task 4: Spike C - environment-aware interpreter contract
+
+**Files:**
+- Modify: `packages/core/src/fold.ts`
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/core/src/interpreters/core.ts`
+- Modify: `packages/core/src/plugins/error/interpreter.ts`
+- Modify: `packages/core/src/plugins/fiber/interpreter.ts`
+- Modify: `packages/plugin-zod/src/interpreter.ts`
+- Test: `packages/core/tests/interpreters/lambda-scope-spikes.test.ts`
+
+**Step 1: Add alternative interpreter type with explicit env/context**
+
+```ts
+type EvalEnv = ReadonlyMap<number, unknown>;
+type EnvHandler = (node: TypedNode, env: EvalEnv) => AsyncGenerator<...>;
+```
+
+Implement separate fold entrypoint (`foldASTWithEnv`) so baseline API remains intact.
+
+**Step 2: Update core lambda_param and selected plugins to env-aware calls**
+
+- `core/lambda_param` reads from env by `__id`.
+- Lambda application extends env in evaluator-managed child evaluation.
+
+**Step 3: Run targeted tests**
+
+Run: `pnpm --filter @mvfm/core test -- tests/interpreters/lambda-scope-spikes.test.ts`
+Expected: PASS for Spike C mode
+
+**Step 4: Commit Spike C**
+
+```bash
+git add packages/core/src/fold.ts packages/core/src/index.ts packages/core/src/interpreters/core.ts packages/core/src/plugins/error/interpreter.ts packages/core/src/plugins/fiber/interpreter.ts packages/plugin-zod/src/interpreter.ts packages/core/tests/interpreters/lambda-scope-spikes.test.ts
+git commit -m "spike(core): evaluate env-aware interpreter contract for lexical lambda scope (#195)"
+```
+
+### Task 5: Benchmark and compare the three spikes
+
+**Files:**
+- Create: `packages/core/tests/interpreters/lambda-scope-spikes.bench.test.ts`
+- Modify: `docs/plans/2026-02-16-lambda-scope-spikes-design.md` (comparison section)
+
+**Step 1: Add benchmark-like deterministic comparison tests**
+
+Measure per-mode:
+- invocation correctness under nested-shadowing
+- allocation proxy metric (clone count via instrumentation)
+- stable DAG cache hit behavior
+
+**Step 2: Run comparison tests**
+
+Run: `pnpm --filter @mvfm/core test -- tests/interpreters/lambda-scope-spikes*.test.ts`
+Expected: PASS with per-mode metrics logged
+
+**Step 3: Record recommendation with evidence**
+
+Write concise table: semantic clarity, plugin churn, DX churn, performance profile.
+
+**Step 4: Commit comparison artifact**
+
+```bash
+git add packages/core/tests/interpreters/lambda-scope-spikes.bench.test.ts docs/plans/2026-02-16-lambda-scope-spikes-design.md
+git commit -m "docs(core): compare lexical lambda scope spike variants (#195)"
+```
+
+### Task 6: Full verification before sharing recommendation
+
+**Files:**
+- No file changes required.
+
+**Step 1: Run required verification suite**
+
+Run: `pnpm run build && pnpm run check && pnpm test`
+Expected: PASS across workspace
+
+**Step 2: Capture exact results in issue-ready summary**
+
+Include:
+- passed/failed suites
+- any expected spike-only deviations
+- final recommended direction
+

--- a/packages/core/etc/core.api.json
+++ b/packages/core/etc/core.api.json
@@ -557,8 +557,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TypedNode",
-              "canonicalReference": "@mvfm/core!TypedNode:interface"
+              "text": "FoldYield",
+              "canonicalReference": "@mvfm/core!FoldYield:type"
             },
             {
               "kind": "Content",
@@ -2096,7 +2096,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@mvfm/core!foldAST:function(1)",
-          "docComment": "/**\n * Stack-safe async fold with WeakMap memoization and taint tracking.\n *\n * - Async generators live on the heap; the call stack is O(1). - Shared nodes (DAG references) evaluate once via WeakMap cache. - Volatile nodes and their dependents re-evaluate each time. - Error propagation via `gen.throw()` — handlers can try/catch. - Accepts optional `FoldState` for cache sharing across calls.\n */\n",
+          "docComment": "/**\n * Stack-safe async fold with memoization and taint tracking.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2280,6 +2280,42 @@
         },
         {
           "kind": "TypeAlias",
+          "canonicalReference": "@mvfm/core!FoldYield:type",
+          "docComment": "/**\n * Values handlers can yield to the fold trampoline.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type FoldYield = "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " | "
+            },
+            {
+              "kind": "Reference",
+              "text": "RecurseScopedEffect",
+              "canonicalReference": "@mvfm/core!RecurseScopedEffect:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "dist/fold.d.ts",
+          "releaseTag": "Public",
+          "name": "FoldYield",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 4
+          }
+        },
+        {
+          "kind": "TypeAlias",
           "canonicalReference": "@mvfm/core!Handler:type",
           "docComment": "/**\n * Handler type: an async generator for a specific typed node. The return type is inferred from the node's phantom type.\n */\n",
           "excerptTokens": [
@@ -2324,8 +2360,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TypedNode",
-              "canonicalReference": "@mvfm/core!TypedNode:interface"
+              "text": "FoldYield",
+              "canonicalReference": "@mvfm/core!FoldYield:type"
             },
             {
               "kind": "Content",
@@ -2918,8 +2954,8 @@
             },
             {
               "kind": "Reference",
-              "text": "TypedNode",
-              "canonicalReference": "@mvfm/core!TypedNode:interface"
+              "text": "FoldYield",
+              "canonicalReference": "@mvfm/core!FoldYield:type"
             },
             {
               "kind": "Content",
@@ -5521,6 +5557,179 @@
         },
         {
           "kind": "Function",
+          "canonicalReference": "@mvfm/core!recurseScoped:function(1)",
+          "docComment": "/**\n * Build a scoped recurse effect.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function recurseScoped(child: "
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ", bindings: "
+            },
+            {
+              "kind": "Reference",
+              "text": "ScopedBinding",
+              "canonicalReference": "@mvfm/core!ScopedBinding:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "[]"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Reference",
+              "text": "RecurseScopedEffect",
+              "canonicalReference": "@mvfm/core!RecurseScopedEffect:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "dist/fold.d.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 6,
+            "endIndex": 7
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "child",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "bindings",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "recurseScoped"
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/core!RecurseScopedEffect:interface",
+          "docComment": "/**\n * Control effect: evaluate a child under temporary lexical bindings.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface RecurseScopedEffect "
+            }
+          ],
+          "fileUrlPath": "dist/fold.d.ts",
+          "releaseTag": "Public",
+          "name": "RecurseScopedEffect",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/core!RecurseScopedEffect#bindings:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "bindings: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ScopedBinding",
+                  "canonicalReference": "@mvfm/core!ScopedBinding:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "bindings",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/core!RecurseScopedEffect#child:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "child: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TypedNode",
+                  "canonicalReference": "@mvfm/core!TypedNode:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "child",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/core!RecurseScopedEffect#type:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "type: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"recurse_scoped\""
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "type",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Function",
           "canonicalReference": "@mvfm/core!resolveSchemaType:function(1)",
           "docComment": "/**\n * Resolves the schema type of a property access chain rooted at `core/input`.\n *\n * Walks backwards through nested `core/prop_access` nodes to reconstruct the access path, then looks it up in the schema.\n *\n * @param node - A `core/prop_access` AST node.\n *\n * @param schema - The program's input schema.\n *\n * @returns The schema type string or `null` if the path doesn't resolve.\n */\n",
           "excerptTokens": [
@@ -5708,6 +5917,78 @@
             "startIndex": 1,
             "endIndex": 9
           }
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@mvfm/core!ScopedBinding:interface",
+          "docComment": "/**\n * Runtime binding for scoped lambda evaluation.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface ScopedBinding "
+            }
+          ],
+          "fileUrlPath": "dist/fold.d.ts",
+          "releaseTag": "Public",
+          "name": "ScopedBinding",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/core!ScopedBinding#paramId:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "paramId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "paramId",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@mvfm/core!ScopedBinding#value:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "value: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "unknown"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "value",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
         },
         {
           "kind": "Variable",

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -43,7 +43,7 @@ export function checkCompleteness(interpreter: Interpreter, root: TypedNode): vo
 
 // @public
 export type CompleteInterpreter<K extends string> = {
-    [key in K]: (node: any) => AsyncGenerator<TypedNode, unknown, unknown>;
+    [key in K]: (node: any) => AsyncGenerator<FoldYield, unknown, unknown>;
 };
 
 // @public
@@ -140,7 +140,10 @@ export interface FoldState {
 }
 
 // @public
-export type Handler<N extends TypedNode<any>> = N extends TypedNode<infer T> ? (node: N) => AsyncGenerator<TypedNode, T, unknown> : never;
+export type FoldYield = TypedNode | RecurseScopedEffect;
+
+// @public
+export type Handler<N extends TypedNode<any>> = N extends TypedNode<infer T> ? (node: N) => AsyncGenerator<FoldYield, T, unknown> : never;
 
 // Warning: (ae-incompatible-release-tags) The symbol "heytingAlgebra" is marked as @public, but its signature references "TypeclassSlot" which is marked as @internal
 //
@@ -174,7 +177,7 @@ export function inferType(node: any, impls: TraitImpl[], schema?: Record<string,
 export function injectLambdaParam(node: any, name: string, value: unknown): void;
 
 // @public
-export type Interpreter = Record<string, (node: any) => AsyncGenerator<TypedNode, unknown, unknown>>;
+export type Interpreter = Record<string, (node: any) => AsyncGenerator<FoldYield, unknown, unknown>>;
 
 // Warning: (ae-internal-missing-underscore) The name "MissingTraitError" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -327,6 +330,19 @@ export interface Program {
 }
 
 // @public
+export function recurseScoped(child: TypedNode, bindings: ScopedBinding[]): RecurseScopedEffect;
+
+// @public
+export interface RecurseScopedEffect {
+    // (undocumented)
+    bindings: ScopedBinding[];
+    // (undocumented)
+    child: TypedNode;
+    // (undocumented)
+    type: "recurse_scoped";
+}
+
+// @public
 export function resolveSchemaType(node: any, schema?: Record<string, unknown>): string | null;
 
 // @public
@@ -339,6 +355,14 @@ export type SchemaTag = "string" | "number" | "boolean" | "date" | "null";
 export type SchemaType = SchemaTag | ArraySchema | NullableSchema | {
     readonly [key: string]: SchemaType;
 };
+
+// @public
+export interface ScopedBinding {
+    // (undocumented)
+    paramId: number;
+    // (undocumented)
+    value: unknown;
+}
 
 // Warning: (ae-incompatible-release-tags) The symbol "semigroup" is marked as @public, but its signature references "TypeclassSlot" which is marked as @internal
 //

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,8 +5,11 @@ export { injectLambdaParam, mvfm } from "./core";
 export type {
   CompleteInterpreter,
   FoldState,
+  FoldYield,
   Handler,
   Interpreter,
+  RecurseScopedEffect,
+  ScopedBinding,
   TypedNode,
   TypedProgram,
 } from "./fold";
@@ -16,6 +19,7 @@ export {
   createFoldState,
   eval_,
   foldAST,
+  recurseScoped,
   typedFoldAST,
   VOLATILE_KINDS,
 } from "./fold";

--- a/packages/core/src/plugins/fiber/interpreter.ts
+++ b/packages/core/src/plugins/fiber/interpreter.ts
@@ -1,5 +1,5 @@
 import type { Interpreter, TypedNode } from "../../fold";
-import { eval_, foldAST } from "../../fold";
+import { eval_, foldAST, recurseScoped } from "../../fold";
 import { injectLambdaParam } from "../../utils";
 
 // ---- Typed node interfaces ----------------------------------
@@ -41,9 +41,7 @@ export const fiberInterpreter: Interpreter = {
     for (let i = 0; i < collection.length; i += node.concurrency) {
       const batch = collection.slice(i, i + node.concurrency);
       for (const item of batch) {
-        const bodyClone = structuredClone(node.body);
-        injectLambdaParam(bodyClone, node.param.name, item);
-        results.push(yield* eval_(bodyClone));
+        results.push(yield recurseScoped(node.body, [{ paramId: node.param.__id, value: item }]));
       }
     }
     return results;

--- a/packages/core/tests/interpreters/lambda-scope-spikes-a-b.ts
+++ b/packages/core/tests/interpreters/lambda-scope-spikes-a-b.ts
@@ -1,0 +1,226 @@
+import { type Counters, inc, lookupScope, type Node } from "./lambda-scope-spikes-types";
+
+type Binding = { paramId: number; value: unknown };
+
+export function runApproachA(root: Node, counters: Counters): unknown {
+  type YieldA = Node | { type: "recurse_scoped"; child: Node; bindings: Binding[] };
+  const cache = new WeakMap<object, unknown>();
+  const tainted = new WeakSet<object>();
+  const frames: Map<number, unknown>[] = [];
+
+  function* visit(node: Node): Generator<YieldA, unknown, unknown> {
+    switch (node.kind) {
+      case "core/literal":
+        return node.value;
+      case "core/lambda_param":
+        return lookupScope(frames, node.__id);
+      case "core/tuple": {
+        const out: unknown[] = [];
+        for (const e of node.elements) out.push(yield e);
+        return out;
+      }
+      case "num/add":
+        return (yield node.left) + (yield node.right);
+      case "spike/counted":
+        inc(counters, node.id);
+        return node.value;
+      case "spike/invoke":
+        return yield {
+          type: "recurse_scoped",
+          child: node.lambda.body,
+          bindings: [{ paramId: node.lambda.param.__id, value: yield node.arg }],
+        };
+      case "spike/par_map": {
+        const items = (yield node.collection) as unknown[];
+        const out: unknown[] = [];
+        for (const item of items) {
+          out.push(
+            yield {
+              type: "recurse_scoped",
+              child: node.body,
+              bindings: [{ paramId: node.param.__id, value: item }],
+            },
+          );
+        }
+        return out;
+      }
+      case "spike/try":
+        try {
+          return yield node.expr;
+        } catch (e) {
+          return yield {
+            type: "recurse_scoped",
+            child: node.catch.body,
+            bindings: [{ paramId: node.catch.param.__id, value: e }],
+          };
+        }
+      case "spike/throw":
+        throw yield node.error;
+      case "core/apply_lambda":
+        throw new Error("Approach A does not use core/apply_lambda");
+    }
+  }
+
+  return evalWithScopedEffect(root, visit, cache, tainted, frames);
+}
+
+function evalWithScopedEffect(
+  root: Node,
+  visit: (
+    node: Node,
+  ) => Generator<
+    Node | { type: "recurse_scoped"; child: Node; bindings: Binding[] },
+    unknown,
+    unknown
+  >,
+  cache: WeakMap<object, unknown>,
+  tainted: WeakSet<object>,
+  frames: Map<number, unknown>[],
+): unknown {
+  function evalNode(node: Node): unknown {
+    if (!tainted.has(node as object) && cache.has(node as object)) return cache.get(node as object);
+    const gen = visit(node);
+    const children = new Set<object>();
+    let input: unknown;
+    let throwErr = false;
+    while (true) {
+      const step = throwErr ? gen.throw(input) : gen.next(input);
+      throwErr = false;
+      if (step.done) {
+        const shouldTaint =
+          node.kind === "core/lambda_param" || [...children].some((c) => tainted.has(c));
+        if (shouldTaint) {
+          tainted.add(node as object);
+          cache.delete(node as object);
+        } else {
+          cache.set(node as object, step.value);
+        }
+        return step.value;
+      }
+      try {
+        if (typeof step.value === "object" && step.value !== null && "type" in step.value) {
+          const frame = new Map<number, unknown>(
+            step.value.bindings.map((b) => [b.paramId, b.value]),
+          );
+          frames.push(frame);
+          try {
+            input = evalNode(step.value.child);
+            children.add(step.value.child as object);
+          } finally {
+            frames.pop();
+          }
+        } else {
+          input = evalNode(step.value as Node);
+          children.add(step.value as object);
+        }
+      } catch (e) {
+        input = e;
+        throwErr = true;
+      }
+    }
+  }
+  return evalNode(root);
+}
+
+export function runApproachB(root: Node, counters: Counters): unknown {
+  const cache = new WeakMap<object, unknown>();
+  const tainted = new WeakSet<object>();
+  const frames: Map<number, unknown>[] = [];
+
+  function* visit(node: Node): Generator<Node, unknown, unknown> {
+    switch (node.kind) {
+      case "core/literal":
+        return node.value;
+      case "core/lambda_param":
+        return lookupScope(frames, node.__id);
+      case "core/tuple": {
+        const out: unknown[] = [];
+        for (const e of node.elements) out.push(yield e);
+        return out;
+      }
+      case "num/add":
+        return (yield node.left) + (yield node.right);
+      case "spike/counted":
+        inc(counters, node.id);
+        return node.value;
+      case "spike/invoke":
+        return yield {
+          kind: "core/apply_lambda",
+          param: node.lambda.param,
+          body: node.lambda.body,
+          arg: node.arg,
+        };
+      case "spike/par_map": {
+        const items = (yield node.collection) as unknown[];
+        const out: unknown[] = [];
+        for (const item of items) {
+          out.push(
+            yield {
+              kind: "core/apply_lambda",
+              param: node.param,
+              body: node.body,
+              arg: { kind: "core/literal", value: item },
+            },
+          );
+        }
+        return out;
+      }
+      case "spike/try":
+        try {
+          return yield node.expr;
+        } catch (e) {
+          return yield {
+            kind: "core/apply_lambda",
+            param: node.catch.param,
+            body: node.catch.body,
+            arg: { kind: "core/literal", value: e },
+          };
+        }
+      case "spike/throw":
+        throw yield node.error;
+      case "core/apply_lambda":
+        throw new Error("Evaluator handles core/apply_lambda directly");
+    }
+  }
+
+  function evalNode(node: Node): unknown {
+    if (node.kind === "core/apply_lambda") {
+      const arg = evalNode(node.arg);
+      frames.push(new Map([[node.param.__id, arg]]));
+      try {
+        return evalNode(node.body);
+      } finally {
+        frames.pop();
+      }
+    }
+    if (!tainted.has(node as object) && cache.has(node as object)) return cache.get(node as object);
+    const gen = visit(node);
+    const children = new Set<object>();
+    let input: unknown;
+    let throwErr = false;
+    while (true) {
+      const step = throwErr ? gen.throw(input) : gen.next(input);
+      throwErr = false;
+      if (step.done) {
+        const shouldTaint =
+          node.kind === "core/lambda_param" || [...children].some((c) => tainted.has(c));
+        if (shouldTaint) {
+          tainted.add(node as object);
+          cache.delete(node as object);
+        } else {
+          cache.set(node as object, step.value);
+        }
+        return step.value;
+      }
+      try {
+        input = evalNode(step.value as Node);
+        children.add(step.value as object);
+      } catch (e) {
+        input = e;
+        throwErr = true;
+      }
+    }
+  }
+
+  return evalNode(root);
+}

--- a/packages/core/tests/interpreters/lambda-scope-spikes-c.ts
+++ b/packages/core/tests/interpreters/lambda-scope-spikes-c.ts
@@ -1,0 +1,85 @@
+import { type Counters, inc, type Node } from "./lambda-scope-spikes-types";
+
+export function runApproachC(root: Node, counters: Counters): unknown {
+  const cache = new WeakMap<object, unknown>();
+  const tainted = new WeakSet<object>();
+
+  function evalNode(node: Node, env: Map<number, unknown>): unknown {
+    if (
+      node.kind !== "core/lambda_param" &&
+      !tainted.has(node as object) &&
+      cache.has(node as object)
+    ) {
+      return cache.get(node as object);
+    }
+    const children = new Set<object>();
+    const value = (() => {
+      switch (node.kind) {
+        case "core/literal":
+          return node.value;
+        case "core/lambda_param":
+          if (!env.has(node.__id)) throw new Error(`Unbound lambda param id=${node.__id}`);
+          return env.get(node.__id);
+        case "core/tuple":
+          return node.elements.map((e) => {
+            children.add(e as object);
+            return evalNode(e, env);
+          });
+        case "num/add": {
+          children.add(node.left as object);
+          children.add(node.right as object);
+          return (evalNode(node.left, env) as number) + (evalNode(node.right, env) as number);
+        }
+        case "spike/counted":
+          inc(counters, node.id);
+          return node.value;
+        case "spike/invoke": {
+          children.add(node.arg as object);
+          children.add(node.lambda.body as object);
+          const next = new Map(env);
+          next.set(node.lambda.param.__id, evalNode(node.arg, env));
+          return evalNode(node.lambda.body, next);
+        }
+        case "spike/par_map": {
+          children.add(node.collection as object);
+          children.add(node.body as object);
+          return (evalNode(node.collection, env) as unknown[]).map((item) => {
+            const next = new Map(env);
+            next.set(node.param.__id, item);
+            return evalNode(node.body, next);
+          });
+        }
+        case "spike/try":
+          try {
+            children.add(node.expr as object);
+            return evalNode(node.expr, env);
+          } catch (e) {
+            children.add(node.catch.body as object);
+            const next = new Map(env);
+            next.set(node.catch.param.__id, e);
+            return evalNode(node.catch.body, next);
+          }
+        case "spike/throw":
+          throw evalNode(node.error, env);
+        case "core/apply_lambda": {
+          children.add(node.body as object);
+          const next = new Map(env);
+          next.set(node.param.__id, evalNode(node.arg, env));
+          return evalNode(node.body, next);
+        }
+      }
+    })();
+
+    const shouldTaint =
+      node.kind === "core/lambda_param" || [...children].some((c) => tainted.has(c));
+    if (shouldTaint) {
+      tainted.add(node as object);
+      cache.delete(node as object);
+    } else {
+      cache.set(node as object, value);
+    }
+    return value;
+  }
+
+  return evalNode(root, new Map<number, unknown>());
+}

--- a/packages/core/tests/interpreters/lambda-scope-spikes-runtime.ts
+++ b/packages/core/tests/interpreters/lambda-scope-spikes-runtime.ts
@@ -1,0 +1,3 @@
+export { runApproachA, runApproachB } from "./lambda-scope-spikes-a-b";
+export { runApproachC } from "./lambda-scope-spikes-c";
+export { type Node, param } from "./lambda-scope-spikes-types";

--- a/packages/core/tests/interpreters/lambda-scope-spikes-types.ts
+++ b/packages/core/tests/interpreters/lambda-scope-spikes-types.ts
@@ -1,0 +1,30 @@
+export type ParamNode = { kind: "core/lambda_param"; __id: number; name: string };
+export type Lambda = { param: ParamNode; body: Node };
+export type Node =
+  | { kind: "core/literal"; value: unknown }
+  | ParamNode
+  | { kind: "core/tuple"; elements: Node[] }
+  | { kind: "num/add"; left: Node; right: Node }
+  | { kind: "spike/invoke"; lambda: Lambda; arg: Node }
+  | { kind: "spike/par_map"; collection: Node; param: ParamNode; body: Node }
+  | { kind: "spike/try"; expr: Node; catch: { param: ParamNode; body: Node } }
+  | { kind: "spike/throw"; error: Node }
+  | { kind: "spike/counted"; id: string; value: unknown }
+  | { kind: "core/apply_lambda"; param: ParamNode; body: Node; arg: Node };
+
+export type Counters = Map<string, number>;
+
+export function param(id: number, name: string): ParamNode {
+  return { kind: "core/lambda_param", __id: id, name };
+}
+
+export function inc(counters: Counters, key: string): void {
+  counters.set(key, (counters.get(key) ?? 0) + 1);
+}
+
+export function lookupScope(frames: Map<number, unknown>[], id: number): unknown {
+  for (let i = frames.length - 1; i >= 0; i--) {
+    if (frames[i].has(id)) return frames[i].get(id);
+  }
+  throw new Error(`Unbound lambda param id=${id}`);
+}

--- a/packages/core/tests/interpreters/lambda-scope-spikes.test.ts
+++ b/packages/core/tests/interpreters/lambda-scope-spikes.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  type Node,
+  param,
+  runApproachA,
+  runApproachB,
+  runApproachC,
+} from "./lambda-scope-spikes-runtime";
+
+describe("lambda scope spikes", () => {
+  const approaches = [
+    ["A: recurse_scoped effect", runApproachA],
+    ["B: core/apply_lambda node", runApproachB],
+    ["C: env-aware contract", runApproachC],
+  ] as const;
+
+  it.each(approaches)("%s preserves lexical shadowing by param identity", (_name, run) => {
+    const outer = param(1, "x");
+    const inner = param(2, "x");
+    const ast: Node = {
+      kind: "spike/invoke",
+      lambda: {
+        param: outer,
+        body: {
+          kind: "core/tuple",
+          elements: [
+            outer,
+            {
+              kind: "spike/invoke",
+              lambda: { param: inner, body: inner },
+              arg: { kind: "core/literal", value: 99 },
+            },
+          ],
+        },
+      },
+      arg: { kind: "core/literal", value: 10 },
+    };
+
+    expect(run(ast, new Map())).toEqual([10, 99]);
+  });
+
+  it.each(
+    approaches,
+  )("%s reuses stable subnodes across repeated lambda applications", (_name, run) => {
+    const p = param(3, "item");
+    const counters = new Map<string, number>();
+    const ast: Node = {
+      kind: "spike/par_map",
+      collection: { kind: "core/literal", value: [1, 2, 3] },
+      param: p,
+      body: {
+        kind: "num/add",
+        left: p,
+        right: { kind: "spike/counted", id: "stable", value: 100 },
+      },
+    };
+
+    expect(run(ast, counters)).toEqual([101, 102, 103]);
+    expect(counters.get("stable")).toBe(1);
+  });
+
+  it.each(approaches)("%s applies lexical binding for try/catch lambda", (_name, run) => {
+    const err = param(4, "err");
+    const ast: Node = {
+      kind: "spike/try",
+      expr: { kind: "spike/throw", error: { kind: "core/literal", value: "boom" } },
+      catch: { param: err, body: { kind: "core/tuple", elements: [err, err] } },
+    };
+
+    expect(run(ast, new Map())).toEqual(["boom", "boom"]);
+  });
+});

--- a/packages/core/tests/interpreters/scoped-recurse.test.ts
+++ b/packages/core/tests/interpreters/scoped-recurse.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { Interpreter, TypedNode } from "../../src/fold";
+import { eval_, foldAST } from "../../src/fold";
+import { coreInterpreter } from "../../src/interpreters/core";
+
+interface InvokeNode extends TypedNode<unknown> {
+  kind: "test/invoke";
+  param: { kind: "core/lambda_param"; __id: number; name: string };
+  arg: TypedNode;
+  body: TypedNode;
+}
+
+interface PairNode extends TypedNode<[unknown, unknown]> {
+  kind: "test/pair";
+  left: TypedNode;
+  right: TypedNode;
+}
+
+interface CounterNode extends TypedNode<number> {
+  kind: "test/counter";
+  id: string;
+  value: number;
+}
+
+function createInterpreter(counters: Map<string, number>): Interpreter {
+  const testInterpreter: Interpreter = {
+    "test/invoke": async function* (node: InvokeNode) {
+      const arg = yield* eval_(node.arg);
+      return yield {
+        type: "recurse_scoped",
+        child: node.body,
+        bindings: [{ paramId: node.param.__id, value: arg }],
+      } as any;
+    },
+    "test/pair": async function* (node: PairNode) {
+      return [(yield* eval_(node.left)) as unknown, (yield* eval_(node.right)) as unknown];
+    },
+    // biome-ignore lint/correctness/useYield: leaf handler returns directly
+    "test/counter": async function* (node: CounterNode) {
+      counters.set(node.id, (counters.get(node.id) ?? 0) + 1);
+      return node.value;
+    },
+  };
+
+  return {
+    ...coreInterpreter,
+    ...testInterpreter,
+  };
+}
+
+describe("foldAST recurse_scoped", () => {
+  it("binds lambda params lexically by param id", async () => {
+    const counters = new Map<string, number>();
+    const interpreter = createInterpreter(counters);
+
+    const outerParam = { kind: "core/lambda_param", __id: 101, name: "x" } as const;
+    const innerParam = { kind: "core/lambda_param", __id: 202, name: "x" } as const;
+
+    const nestedInvoke: InvokeNode = {
+      kind: "test/invoke",
+      param: innerParam,
+      arg: { kind: "core/literal", value: 99 },
+      body: innerParam,
+    };
+
+    const ast: InvokeNode = {
+      kind: "test/invoke",
+      param: outerParam,
+      arg: { kind: "core/literal", value: 10 },
+      body: {
+        kind: "core/tuple",
+        elements: [outerParam, nestedInvoke],
+      },
+    };
+
+    await expect(foldAST(interpreter, ast)).resolves.toEqual([10, 99]);
+  });
+
+  it("keeps stable child cached across scoped invocations", async () => {
+    const counters = new Map<string, number>();
+    const interpreter = createInterpreter(counters);
+
+    const itemParam = { kind: "core/lambda_param", __id: 303, name: "item" } as const;
+    const body: PairNode = {
+      kind: "test/pair",
+      left: itemParam,
+      right: { kind: "test/counter", id: "stable", value: 7 },
+    };
+
+    const ast: PairNode = {
+      kind: "test/pair",
+      left: {
+        kind: "test/invoke",
+        param: itemParam,
+        arg: { kind: "core/literal", value: 1 },
+        body,
+      },
+      right: {
+        kind: "test/invoke",
+        param: itemParam,
+        arg: { kind: "core/literal", value: 2 },
+        body,
+      },
+    };
+
+    await expect(foldAST(interpreter, ast)).resolves.toEqual([
+      [1, 7],
+      [2, 7],
+    ]);
+    expect(counters.get("stable")).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #195

## What this does
This replaces clone-and-mutate lambda application in the main interpreter paths with immutable scoped evaluation. `foldAST` now supports a scoped recurse control variant (`recurse_scoped`) keyed by lambda param node identity (`__id`), and `error`, `fiber` (sequential `par_map`), and zod lambda evaluation paths now use scoped bindings instead of `structuredClone` + `injectLambdaParam`. It also adds focused regression tests for lexical scoping behavior and updates the core API report exports.

## Design alignment
- **VISION Principle 1: Programs are data.** Lambda application no longer requires mutating AST subtrees in these paths; the same AST is evaluated under runtime scope bindings, preserving immutable program-data semantics.
- **VISION Principle 4: The interpreter is someone else's problem.** The change is fully runtime/interpreter-side (`foldAST` + interpreter fragments) and does not change the DSL/plugin builder contract or lambda builder API.
- **Issue scope alignment.** The migration targets the core callsites discussed in #195 and keeps plugin contract surface unchanged.

## Validation performed
- `pnpm run build` (workspace): PASS
- `pnpm run check` (workspace): PASS
- `pnpm test` (workspace): PASS
- Added/ran targeted regression coverage:
  - `pnpm --filter @mvfm/core test -- tests/interpreters/scoped-recurse.test.ts tests/plugins/error/interpreter.test.ts tests/plugins/fiber/interpreter.test.ts`
  - `pnpm --filter @mvfm/plugin-zod test -- tests/interpreter.test.ts tests/base.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design and implementation planning documentation detailing approaches to lambda scope evaluation with impact analysis.

* **Tests**
  * Introduced comprehensive test coverage for lambda scope spike implementations, including lexical binding and scoped recursion scenarios.

* **Refactor**
  * Updated core and plugin interpreters to implement improved lambda parameter binding with lexical scope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->