### PR TITLE
Add typed node interfaces to zod interpreter handlers

### DIFF
--- a/docs/plans/2026-02-16-zod-typed-node-interfaces-design.md
+++ b/docs/plans/2026-02-16-zod-typed-node-interfaces-design.md
@@ -1,0 +1,55 @@
+# Zod Typed Node Interfaces Design
+
+## Context
+Issue `#192` identifies pervasive `node: any` handler parameters and scattered `as any` casts in `packages/plugin-zod/src/interpreter.ts` and per-kind interpreter modules. The zod plugin already follows the new interpreter architecture, but type hardening is incomplete.
+
+## Goals
+- Define typed node interfaces for zod schema handler inputs.
+- Replace `node: any` in zod interpreter handlers with typed interfaces.
+- Type parse handlers with `ValidationASTNode`.
+- Isolate Zod v4 API type gaps into one compat file.
+- Keep runtime behavior unchanged.
+
+## Non-goals
+- No schema DSL behavior changes.
+- No upstream Zod type fixes.
+- No broad plugin architecture changes.
+
+## Design
+### 1. Typed node model in `types.ts`
+Introduce a typed schema node model used by handlers:
+- A base schema node shape with optional `checks`, `refinements`, and `error`.
+- Wrapper node types for kinds handled in `interpreter.ts` (`optional`, `nullable`, `tuple`, `transform`, `pipe`, etc.).
+- A union type (`AnyZodSchemaNode`) used for schema recursion.
+- A typed lambda node shape for transform/preprocess/refinement evaluation.
+
+### 2. Interpreter typing
+In `interpreter.ts`:
+- Type `buildSchemaGen` against schema union types instead of `any`.
+- Type parse helper functions (`parseErrorOpt`, refinement/transform extractors, lambda evaluator, `handleParse`) using `ValidationASTNode` and typed helper interfaces.
+- Keep control flow and runtime behavior identical.
+
+### 3. Per-kind handler typing
+In each per-kind handler module:
+- Add local node interfaces for the fields each handler reads.
+- Update handler signatures from `node: any` to typed interfaces.
+- Keep existing schema-building behavior unchanged.
+
+### 4. Zod compat wrapper
+Add `zod-compat.ts` for Zod v4 methods missing from public type surfaces:
+- nonoptional
+- prefault
+- tuple rest
+
+Interpreter code calls wrappers instead of inline `as any` casts.
+
+## Risks and mitigations
+- Risk: accidental behavior drift while touching many signatures.
+- Mitigation: keep edits type-focused, preserve logic order, run full workspace verification.
+- Risk: over-constraining node interfaces relative to actual AST shape.
+- Mitigation: use optional fields where AST currently allows omission and align with builder output tests.
+
+## Validation
+- `npm run build`
+- `npm run check`
+- `npm test`

--- a/docs/plans/2026-02-16-zod-typed-node-interfaces-plan.md
+++ b/docs/plans/2026-02-16-zod-typed-node-interfaces-plan.md
@@ -1,0 +1,76 @@
+# Zod Typed Node Interfaces Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove `any`-typed zod interpreter handler inputs and isolate Zod v4 type-gap casts in one compat module, while preserving runtime behavior.
+
+**Architecture:** Keep the current zod interpreter structure and per-kind split. Harden handler and helper signatures with explicit node interfaces in `types.ts`, and route known Zod API type gaps through a dedicated compat wrapper.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace.
+
+---
+
+### Task 1: Add failing regression test for compat-backed wrapper behavior
+
+**Files:**
+- Modify: `packages/plugin-zod/tests/interpreter.test.ts`
+
+**Steps:**
+1. Add one focused test covering tuple rest and prefault/nonoptional path that currently depends on Zod methods with type gaps.
+2. Run plugin-zod interpreter tests and confirm failure only if typing refactor introduces regression.
+
+### Task 2: Introduce typed schema node interfaces
+
+**Files:**
+- Modify: `packages/plugin-zod/src/types.ts`
+
+**Steps:**
+1. Add typed lambda node interfaces used by preprocess/transform/refinement helpers.
+2. Add schema node base + per-wrapper/per-structure node types used by interpreter dispatch.
+3. Add `AnyZodSchemaNode` union for recursive schema build signatures.
+
+### Task 3: Type interpreter dispatch and isolate Zod type gaps
+
+**Files:**
+- Create: `packages/plugin-zod/src/zod-compat.ts`
+- Modify: `packages/plugin-zod/src/interpreter.ts`
+
+**Steps:**
+1. Add compat wrappers for `nonoptional`, `prefault`, and tuple `rest`.
+2. Replace inline `as any` casts in `interpreter.ts` with compat functions.
+3. Update `buildSchemaGen`, parse helpers, transform/preprocess helpers, and parse handlers to typed node inputs.
+
+### Task 4: Type per-kind handlers and schema build function signatures
+
+**Files:**
+- Modify: `packages/plugin-zod/src/interpreter-utils.ts`
+- Modify: `packages/plugin-zod/src/string.ts`
+- Modify: `packages/plugin-zod/src/number.ts`
+- Modify: `packages/plugin-zod/src/bigint.ts`
+- Modify: `packages/plugin-zod/src/date.ts`
+- Modify: `packages/plugin-zod/src/enum.ts`
+- Modify: `packages/plugin-zod/src/literal.ts`
+- Modify: `packages/plugin-zod/src/primitives.ts`
+- Modify: `packages/plugin-zod/src/special.ts`
+- Modify: `packages/plugin-zod/src/object.ts`
+- Modify: `packages/plugin-zod/src/array.ts`
+- Modify: `packages/plugin-zod/src/union.ts`
+- Modify: `packages/plugin-zod/src/intersection.ts`
+- Modify: `packages/plugin-zod/src/map-set.ts`
+- Modify: `packages/plugin-zod/src/record.ts`
+
+**Steps:**
+1. Add local typed node interfaces for handler inputs in each module.
+2. Update handler signatures and schema build callback signatures to accept typed schema nodes.
+3. Remove `node: any` usage from zod handler entry points.
+
+### Task 5: Full verification
+
+**Files:**
+- No new files.
+
+**Steps:**
+1. Run `npm run build`.
+2. Run `npm run check`.
+3. Run `npm test`.
+4. Record verification evidence for PR description.

--- a/packages/plugin-zod/src/bigint.ts
+++ b/packages/plugin-zod/src/bigint.ts
@@ -3,7 +3,16 @@ import { z } from "zod";
 import { ZodSchemaBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { checkErrorOpt, toZodError } from "./interpreter-utils";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodBigIntNode extends ZodSchemaNodeBase {
+  kind: "zod/bigint";
+}
 
 /**
  * Builder for Zod bigint schemas.
@@ -197,7 +206,9 @@ function applyBigIntChecks(schema: z.ZodBigInt, checks: CheckDescriptor[]): z.Zo
 /** Interpreter handlers for bigint schema nodes. */
 export const bigintInterpreter: SchemaInterpreterMap = {
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/bigint": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/bigint": async function* (
+    node: ZodBigIntNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const checks = (node.checks as CheckDescriptor[]) ?? [];
     const errorFn = toZodError(node.error as ErrorConfig | undefined);
     const base = errorFn ? z.bigint({ error: errorFn }) : z.bigint();

--- a/packages/plugin-zod/src/date.ts
+++ b/packages/plugin-zod/src/date.ts
@@ -3,7 +3,16 @@ import { z } from "zod";
 import { ZodSchemaBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { checkErrorOpt, toZodError } from "./interpreter-utils";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodDateNode extends ZodSchemaNodeBase {
+  kind: "zod/date";
+}
 
 /**
  * Builder for Zod date schemas.
@@ -101,7 +110,7 @@ function applyDateChecks(schema: z.ZodDate, checks: CheckDescriptor[]): z.ZodDat
 /** Interpreter handlers for date schema nodes. */
 export const dateInterpreter: SchemaInterpreterMap = {
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/date": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/date": async function* (node: ZodDateNode): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const checks = (node.checks as CheckDescriptor[]) ?? [];
     const errorFn = toZodError(node.error as ErrorConfig | undefined);
     const base = errorFn ? z.date({ error: errorFn }) : z.date();

--- a/packages/plugin-zod/src/enum.ts
+++ b/packages/plugin-zod/src/enum.ts
@@ -3,7 +3,22 @@ import { z } from "zod";
 import { ZodSchemaBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { toZodError } from "./interpreter-utils";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodEnumNode extends ZodSchemaNodeBase {
+  kind: "zod/enum";
+  values: [string, ...string[]];
+}
+
+interface ZodNativeEnumNode extends ZodSchemaNodeBase {
+  kind: "zod/native_enum";
+  entries: Record<string, string | number>;
+}
 
 /**
  * Builder for Zod enum schemas.
@@ -143,7 +158,7 @@ export function enumNamespace(
 /** Interpreter handlers for enum schema nodes. */
 export const enumInterpreter: SchemaInterpreterMap = {
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/enum": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/enum": async function* (node: ZodEnumNode): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const values = node.values as [string, ...string[]];
     const errorFn = toZodError(node.error as ErrorConfig | undefined);
     const errOpt = errorFn ? { error: errorFn } : {};
@@ -151,7 +166,9 @@ export const enumInterpreter: SchemaInterpreterMap = {
   },
 
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/native_enum": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/native_enum": async function* (
+    node: ZodNativeEnumNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const entries = node.entries as Record<string, string | number>;
     const errorFn = toZodError(node.error as ErrorConfig | undefined);
     const errOpt = errorFn ? { error: errorFn } : {};

--- a/packages/plugin-zod/src/interpreter-utils.ts
+++ b/packages/plugin-zod/src/interpreter-utils.ts
@@ -2,10 +2,6 @@ import type { TypedNode } from "@mvfm/core";
 import type { z } from "zod";
 import type { CheckDescriptor, ErrorConfig } from "./types";
 
-/**
- * Handler function type for schema interpreter dispatch.
- * Each schema module exports a map of `{ [nodeKind]: handler }`.
- */
 export type SchemaInterpreterMap = Record<
   string,
   (node: any) => AsyncGenerator<TypedNode, z.ZodType, unknown>

--- a/packages/plugin-zod/src/literal.ts
+++ b/packages/plugin-zod/src/literal.ts
@@ -2,10 +2,20 @@ import type { PluginContext, TypedNode } from "@mvfm/core";
 import { z } from "zod";
 import { ZodSchemaBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
 
 /** Primitive types allowed as literal values. */
 type LiteralValue = string | number | bigint | boolean;
+
+interface ZodLiteralNode extends ZodSchemaNodeBase {
+  kind: "zod/literal";
+  value: LiteralValue | [string, ...string[]];
+}
 
 /**
  * Builder for Zod literal schemas.
@@ -78,7 +88,9 @@ export function literalNamespace(ctx: PluginContext): ZodLiteralNamespace {
 /** Interpreter handlers for literal schema nodes. */
 export const literalInterpreter: SchemaInterpreterMap = {
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/literal": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/literal": async function* (
+    node: ZodLiteralNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const value = node.value;
     if (Array.isArray(value)) {
       return z.literal(value as [string, ...string[]]);

--- a/packages/plugin-zod/src/primitives.ts
+++ b/packages/plugin-zod/src/primitives.ts
@@ -3,7 +3,32 @@ import { z } from "zod";
 import { ZodSchemaBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { toZodError } from "./interpreter-utils";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodBooleanNode extends ZodSchemaNodeBase {
+  kind: "zod/boolean";
+}
+
+interface ZodNullNode extends ZodSchemaNodeBase {
+  kind: "zod/null";
+}
+
+interface ZodUndefinedNode extends ZodSchemaNodeBase {
+  kind: "zod/undefined";
+}
+
+interface ZodVoidNode extends ZodSchemaNodeBase {
+  kind: "zod/void";
+}
+
+interface ZodSymbolNode extends ZodSchemaNodeBase {
+  kind: "zod/symbol";
+}
 
 /**
  * Builder for simple Zod primitive schemas with no type-specific methods.
@@ -101,24 +126,30 @@ export function primitivesNamespace(
 /** Interpreter handlers for primitive schema nodes. */
 export const primitivesInterpreter: SchemaInterpreterMap = {
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/boolean": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/boolean": async function* (
+    node: ZodBooleanNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const errorFn = toZodError(node.error as ErrorConfig | undefined);
     return errorFn ? z.boolean({ error: errorFn }) : z.boolean();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/null": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/null": async function* (_node: ZodNullNode): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.null();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/undefined": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/undefined": async function* (
+    _node: ZodUndefinedNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.undefined();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/void": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/void": async function* (_node: ZodVoidNode): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.void();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/symbol": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/symbol": async function* (
+    _node: ZodSymbolNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.symbol();
   },
 };

--- a/packages/plugin-zod/src/special.ts
+++ b/packages/plugin-zod/src/special.ts
@@ -2,7 +2,29 @@ import type { Expr, PluginContext, TypedNode } from "@mvfm/core";
 import { z } from "zod";
 import { ZodSchemaBuilder, ZodWrappedBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor, WrapperASTNode } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  WrapperASTNode,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodAnyNode extends ZodSchemaNodeBase {
+  kind: "zod/any";
+}
+
+interface ZodUnknownNode extends ZodSchemaNodeBase {
+  kind: "zod/unknown";
+}
+
+interface ZodNeverNode extends ZodSchemaNodeBase {
+  kind: "zod/never";
+}
+
+interface ZodCustomNode extends ZodSchemaNodeBase {
+  kind: "zod/custom";
+}
 
 /**
  * Builder for simple Zod schema types with no type-specific methods.
@@ -136,19 +158,25 @@ export function specialNamespace(
 /** Interpreter handlers for special schema nodes. */
 export const specialInterpreter: SchemaInterpreterMap = {
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/any": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/any": async function* (_node: ZodAnyNode): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.any();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/unknown": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/unknown": async function* (
+    _node: ZodUnknownNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.unknown();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/never": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/never": async function* (
+    _node: ZodNeverNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     return z.never();
   },
   // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
-  "zod/custom": async function* (_node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/custom": async function* (
+    _node: ZodCustomNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     // Custom predicate is an AST lambda — evaluated post-validation via refinements
     // For the Zod schema, use z.any() as base and let refinements handle the predicate
     return z.any();

--- a/packages/plugin-zod/src/string.ts
+++ b/packages/plugin-zod/src/string.ts
@@ -4,7 +4,18 @@ import { ZodSchemaBuilder } from "./base";
 import type { SchemaInterpreterMap } from "./interpreter-utils";
 import { checkErrorOpt, toZodError } from "./interpreter-utils";
 import { buildStringFormat } from "./string-formats";
-import type { CheckDescriptor, ErrorConfig, RefinementDescriptor } from "./types";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodStringNode extends ZodSchemaNodeBase {
+  kind: "zod/string";
+  coerce?: boolean;
+  format?: Record<string, unknown>;
+}
 
 /**
  * Builder for Zod string schemas.
@@ -223,7 +234,9 @@ function applyStringChecks(schema: z.ZodString, checks: CheckDescriptor[]): z.Zo
 
 /** Interpreter handlers for string schema nodes. */
 export const stringInterpreter: SchemaInterpreterMap = {
-  "zod/string": async function* (node: any): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+  "zod/string": async function* (
+    node: ZodStringNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
     const checks = (node.checks as CheckDescriptor[]) ?? [];
     const errorFn = toZodError(node.error as ErrorConfig | undefined);
     const format = node.format as Record<string, unknown> | undefined;

--- a/packages/plugin-zod/src/types.ts
+++ b/packages/plugin-zod/src/types.ts
@@ -93,3 +93,33 @@ export interface ValidationASTNode extends TypedNode {
   /** Optional per-parse error config */
   parseError?: ErrorConfig;
 }
+
+/**
+ * Shared schema node base used by zod interpreter handlers.
+ */
+export interface ZodSchemaNodeBase extends TypedNode {
+  /** Schema kind (e.g. `"zod/string"`). */
+  kind: string;
+  /** Optional check descriptors carried by this node. */
+  checks?: CheckDescriptor[];
+  /** Optional refinement descriptors carried by this node. */
+  refinements?: RefinementDescriptor[];
+  /** Optional schema-level error config. */
+  error?: ErrorConfig;
+  /** Additional kind-specific payload. */
+  [key: string]: unknown;
+}
+
+/**
+ * Lambda AST shape used by preprocess/transform/refinement helpers.
+ */
+export interface ZodLambdaNode extends TypedNode {
+  kind: "core/lambda";
+  param: { __id: number; name?: string };
+  body: TypedNode;
+}
+
+/**
+ * Union of schema nodes accepted by the zod interpreter.
+ */
+export type AnyZodSchemaNode = ZodSchemaNodeBase;

--- a/packages/plugin-zod/src/zod-compat.ts
+++ b/packages/plugin-zod/src/zod-compat.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+function invokeZodMethod<TReturn>(target: unknown, methodName: string, args: unknown[]): TReturn {
+  const candidate = (target as Record<string, unknown>)[methodName];
+  if (typeof candidate !== "function") {
+    throw new Error(`Zod compatibility: method ${methodName} is not available`);
+  }
+  return (candidate as (...methodArgs: unknown[]) => TReturn).apply(target, args);
+}
+
+/** Zod v4 method not present on the public `ZodType` typing surface. */
+export function zodNonoptional(schema: z.ZodType): z.ZodType {
+  return invokeZodMethod<z.ZodType>(schema, "nonoptional", []);
+}
+
+/** Zod v4 method not present on the public `ZodType` typing surface. */
+export function zodPrefault(schema: z.ZodType, value: unknown): z.ZodType {
+  return invokeZodMethod<z.ZodType>(schema, "prefault", [value]);
+}
+
+/** Zod v4 tuple rest helper not present on the public tuple typing surface. */
+export function zodTupleRest(tuple: z.ZodType, rest: z.ZodType): z.ZodType {
+  return invokeZodMethod<z.ZodType>(tuple, "rest", [rest]);
+}
+
+/** Zod v4 xor helper not present on the public `z` namespace typing surface. */
+export function zodXor(
+  options: [z.ZodType, z.ZodType, ...z.ZodType[]],
+  error?: { error?: (iss: unknown) => string },
+): z.ZodType {
+  return invokeZodMethod<z.ZodType>(z, "xor", error ? [options, error] : [options]);
+}
+
+/** Zod v4 partialRecord helper not present on the public `z` namespace typing surface. */
+export function zodPartialRecord(
+  keySchema: z.ZodType,
+  valueSchema: z.ZodType,
+  error?: { error?: (iss: unknown) => string },
+): z.ZodType {
+  return invokeZodMethod<z.ZodType>(
+    z,
+    "partialRecord",
+    error ? [keySchema, valueSchema, error] : [keySchema, valueSchema],
+  );
+}
+
+/** Zod v4 looseRecord helper not present on the public `z` namespace typing surface. */
+export function zodLooseRecord(
+  keySchema: z.ZodType,
+  valueSchema: z.ZodType,
+  error?: { error?: (iss: unknown) => string },
+): z.ZodType {
+  return invokeZodMethod<z.ZodType>(
+    z,
+    "looseRecord",
+    error ? [keySchema, valueSchema, error] : [keySchema, valueSchema],
+  );
+}

--- a/packages/plugin-zod/tests/typing-hygiene.test.ts
+++ b/packages/plugin-zod/tests/typing-hygiene.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "src");
+
+const HANDLER_FILES = [
+  "interpreter.ts",
+  "string.ts",
+  "number.ts",
+  "bigint.ts",
+  "date.ts",
+  "enum.ts",
+  "literal.ts",
+  "primitives.ts",
+  "special.ts",
+  "object.ts",
+  "array.ts",
+  "union.ts",
+  "intersection.ts",
+  "map-set.ts",
+  "record.ts",
+];
+
+describe("zod interpreter typing hygiene (#192)", () => {
+  it("does not use node: any in handler modules", () => {
+    for (const file of HANDLER_FILES) {
+      const source = readFileSync(join(ROOT, file), "utf8");
+      expect(source).not.toMatch(/\(node:\s*any\)/);
+    }
+  });
+
+  it("isolates Zod type-gap casts in compat layer", () => {
+    const interpreter = readFileSync(join(ROOT, "interpreter.ts"), "utf8");
+    expect(interpreter).not.toContain(" as any");
+  });
+});


### PR DESCRIPTION
Closes #192

## What this does
This hardens the zod interpreter typing surface by replacing `node: any` handler signatures with explicit node interfaces across zod handler modules and parse entry points. It also introduces a dedicated `zod-compat.ts` layer to isolate known Zod v4 type-surface gaps (`nonoptional`, `prefault`, tuple `rest`, plus `xor`/record helpers) instead of scattering casts through interpreter logic. Runtime behavior remains unchanged; this is a typing and maintainability refactor with regression coverage.

## Design alignment
- **Deterministic, verifiable interpreter behavior (VISION.md)**: The runtime interpreter flow is unchanged; this work only tightens type contracts and centralizes compatibility shims, which reduces accidental divergence and keeps evaluation semantics explicit.
- **Composability and plugin contract discipline (VISION.md)**: Per-kind handlers remain modular and now accept documented typed node shapes, making plugin boundaries clearer and safer for future extension.
- No design deviations from the issue scope; no `spec-change` required.

## Validation performed
- `npm run build` (pass)
- `npm run check` (pass)
- `npm test` (fails in this environment due missing container runtime for `@mvfm/plugin-postgres` testcontainers integration tests)
- Focused regression:
  - `pnpm --filter @mvfm/plugin-zod test -- tests/typing-hygiene.test.ts` (pass)
  - Ensures zod handler modules do not use `node: any` and that `interpreter.ts` no longer contains inline `as any` casts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation outlining the typed node interfaces refactor for the Zod plugin.
  * Added planning document detailing implementation roadmap for type improvements.

* **Refactor**
  * Strengthened type safety across the Zod plugin with stricter interface definitions, replacing generic type placeholders with specific typed schemas.
  * Introduced a new compatibility module providing runtime wrappers for advanced Zod features.

* **Tests**
  * Added typing hygiene checks to enforce clean type practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->