### PR TITLE
feat(core): add typed boolean/num NodeTypeMap registrations

### DIFF
--- a/docs/plans/2026-02-17-issue-210-boolean-num-typed-nodes-design.md
+++ b/docs/plans/2026-02-17-issue-210-boolean-num-typed-nodes-design.md
@@ -1,0 +1,34 @@
+# Issue 210 Boolean/Num Typed Nodes Design
+
+## Goal
+
+Add typed interpreter node contracts for `boolean/*` and `num/*` kinds so `typedInterpreter` enforces handler node shapes through `NodeTypeMap`.
+
+## Scope
+
+- In scope: `packages/core/src/plugins/boolean/interpreter.ts`, `packages/core/src/plugins/num/interpreter.ts`, and representative compile-time checks in `packages/core/src/__tests__/node-type-map.type-test.ts`.
+- Out of scope: runtime behavior changes, plugin surface/API redesign, exhaustive per-kind type tests.
+
+## Approach Options
+
+1. Minimal targeted typing (chosen): type boolean/num interpreter files directly and add representative type tests.
+2. Exhaustive type-test matrix: higher confidence but noisy and high maintenance.
+3. Split node interfaces to separate `nodes.ts`: cleaner factoring but unnecessary refactor for this issue.
+
+## Chosen Design
+
+- Co-locate exported typed node interfaces with each interpreter file, following existing `str`, `eq`, and `ord` patterns.
+- Add `declare module "@mvfm/core"` augmentation for each `boolean/*` and `num/*` kind to register node contracts in `NodeTypeMap`.
+- Replace untyped `Interpreter` maps with `typedInterpreter<Kinds>()` maps.
+- Add compile-time assertions in `node-type-map.type-test.ts` for representative `boolean/not` and `num/neg` kinds (positive and `node:any` rejection).
+
+## Data Flow and Error Handling
+
+- No runtime execution-path changes; handlers still evaluate children with `eval_` and return existing values.
+- Type enforcement now fails at compile time if handler node parameters diverge from registered node contracts.
+
+## Validation Plan
+
+- Red phase: add boolean/num compile-time assertions before implementation and observe TypeScript failure.
+- Green phase: implement typed interfaces + NodeTypeMap augmentation and verify TypeScript passes.
+- Final validation: `npm run build && npm run check && npm test`, plus focused `@mvfm/core` tests if environment-dependent suites fail.

--- a/docs/plans/2026-02-17-issue-210-boolean-num-typed-nodes-implementation-plan.md
+++ b/docs/plans/2026-02-17-issue-210-boolean-num-typed-nodes-implementation-plan.md
@@ -1,0 +1,58 @@
+# Issue 210 Boolean/Num Typed Nodes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add typed node interfaces and `NodeTypeMap` registrations for boolean and num core plugins, and enforce them through `typedInterpreter` with compile-time tests.
+
+**Architecture:** Keep node interface declarations colocated in each plugin interpreter (matching `str`, `eq`, `ord` patterns). Register every boolean/num kind via `declare module "@mvfm/core"` augmentation and switch handler maps from `Interpreter` to `typedInterpreter<Kinds>()`.
+
+**Tech Stack:** TypeScript, module augmentation, typedInterpreter/NodeTypeMap, Vitest + tsc type tests.
+
+---
+
+### Task 1: Add failing type-level checks first (RED)
+
+**Files:**
+- Modify: `packages/core/src/__tests__/node-type-map.type-test.ts`
+
+1. Add positive checks for one boolean and one num kind using inferred node parameter.
+2. Add negative checks with `node: any` for one boolean and one num kind using `@ts-expect-error`.
+3. Run `pnpm --filter @mvfm/core run build` and verify failure due to unregistered kinds still accepting `any`.
+
+### Task 2: Type boolean interpreter and register kinds (GREEN)
+
+**Files:**
+- Modify: `packages/core/src/plugins/boolean/interpreter.ts`
+
+1. Replace `Interpreter` map with typed node interfaces per boolean kind.
+2. Add `declare module "@mvfm/core"` and register all `boolean/*` kinds listed in issue.
+3. Define `BooleanKinds` union and switch export to `typedInterpreter<BooleanKinds>()`.
+4. Keep runtime behavior unchanged.
+
+### Task 3: Type num interpreter and register kinds (GREEN)
+
+**Files:**
+- Modify: `packages/core/src/plugins/num/interpreter.ts`
+
+1. Replace `Interpreter` map with typed node interfaces per num kind.
+2. Add `declare module "@mvfm/core"` and register all `num/*` kinds listed in issue.
+3. Define `NumKinds` union and switch export to `typedInterpreter<NumKinds>()`.
+4. Keep runtime behavior unchanged.
+
+### Task 4: Finalize compile-time checks (REFACTOR)
+
+**Files:**
+- Modify: `packages/core/src/__tests__/node-type-map.type-test.ts`
+
+1. Ensure new type tests compile in positive cases and fail only where `@ts-expect-error` is declared.
+2. Keep tests representative (not exhaustive per kind) to avoid noise.
+
+### Task 5: Verify and report
+
+**Files:**
+- No source changes required.
+
+1. Run `npm run build`.
+2. Run `npm run check`.
+3. Run `npm test`.
+4. Summarize results and changed files.

--- a/packages/core/etc/core.api.json
+++ b/packages/core/etc/core.api.json
@@ -355,9 +355,242 @@
               "text": "booleanInterpreter: "
             },
             {
+              "kind": "Content",
+              "text": "{\n    \"boolean/and\": (node: "
+            },
+            {
               "kind": "Reference",
-              "text": "Interpreter",
-              "canonicalReference": "@mvfm/core!Interpreter:type"
+              "text": "BooleanAndNode",
+              "canonicalReference": "@mvfm/core!~BooleanAndNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, boolean, unknown>;\n    \"boolean/or\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanOrNode",
+              "canonicalReference": "@mvfm/core!~BooleanOrNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, boolean, unknown>;\n    \"boolean/not\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanNotNode",
+              "canonicalReference": "@mvfm/core!~BooleanNotNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, boolean, unknown>;\n    \"boolean/eq\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanEqNode",
+              "canonicalReference": "@mvfm/core!~BooleanEqNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, boolean, unknown>;\n    \"boolean/ff\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanFalseNode",
+              "canonicalReference": "@mvfm/core!~BooleanFalseNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, false, unknown>;\n    \"boolean/tt\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanTrueNode",
+              "canonicalReference": "@mvfm/core!~BooleanTrueNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, true, unknown>;\n    \"boolean/implies\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanImpliesNode",
+              "canonicalReference": "@mvfm/core!~BooleanImpliesNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, boolean, unknown>;\n    \"boolean/show\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanShowNode",
+              "canonicalReference": "@mvfm/core!~BooleanShowNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, string, unknown>;\n    \"boolean/top\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanTopNode",
+              "canonicalReference": "@mvfm/core!~BooleanTopNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, true, unknown>;\n    \"boolean/bottom\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "BooleanBottomNode",
+              "canonicalReference": "@mvfm/core!~BooleanBottomNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, false, unknown>;\n}"
             }
           ],
           "fileUrlPath": "dist/plugins/boolean/interpreter.d.ts",
@@ -366,7 +599,7 @@
           "name": "booleanInterpreter",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 54
           }
         },
         {
@@ -5182,9 +5415,485 @@
               "text": "numInterpreter: "
             },
             {
+              "kind": "Content",
+              "text": "{\n    \"num/add\": (node: "
+            },
+            {
               "kind": "Reference",
-              "text": "Interpreter",
-              "canonicalReference": "@mvfm/core!Interpreter:type"
+              "text": "NumAddNode",
+              "canonicalReference": "@mvfm/core!~NumAddNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/sub\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumSubNode",
+              "canonicalReference": "@mvfm/core!~NumSubNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/mul\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumMulNode",
+              "canonicalReference": "@mvfm/core!~NumMulNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/div\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumDivNode",
+              "canonicalReference": "@mvfm/core!~NumDivNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/mod\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumModNode",
+              "canonicalReference": "@mvfm/core!~NumModNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/compare\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumCompareNode",
+              "canonicalReference": "@mvfm/core!~NumCompareNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, 1 | 0 | -1, unknown>;\n    \"num/neg\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumNegNode",
+              "canonicalReference": "@mvfm/core!~NumNegNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/abs\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumAbsNode",
+              "canonicalReference": "@mvfm/core!~NumAbsNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/floor\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumFloorNode",
+              "canonicalReference": "@mvfm/core!~NumFloorNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/ceil\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumCeilNode",
+              "canonicalReference": "@mvfm/core!~NumCeilNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/round\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumRoundNode",
+              "canonicalReference": "@mvfm/core!~NumRoundNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/min\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumMinNode",
+              "canonicalReference": "@mvfm/core!~NumMinNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/max\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumMaxNode",
+              "canonicalReference": "@mvfm/core!~NumMaxNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, number, unknown>;\n    \"num/eq\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumEqNode",
+              "canonicalReference": "@mvfm/core!~NumEqNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, boolean, unknown>;\n    \"num/zero\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumZeroNode",
+              "canonicalReference": "@mvfm/core!~NumZeroNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, number, unknown>;\n    \"num/one\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumOneNode",
+              "canonicalReference": "@mvfm/core!~NumOneNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, number, unknown>;\n    \"num/show\": (node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumShowNode",
+              "canonicalReference": "@mvfm/core!~NumShowNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "TypedNode",
+              "canonicalReference": "@mvfm/core!TypedNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<unknown>, string, unknown>;\n    \"num/top\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumTopNode",
+              "canonicalReference": "@mvfm/core!~NumTopNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, number, unknown>;\n    \"num/bottom\": (_node: "
+            },
+            {
+              "kind": "Reference",
+              "text": "NumBottomNode",
+              "canonicalReference": "@mvfm/core!~NumBottomNode:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ") => "
+            },
+            {
+              "kind": "Reference",
+              "text": "AsyncGenerator",
+              "canonicalReference": "!AsyncGenerator:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<never, number, unknown>;\n}"
             }
           ],
           "fileUrlPath": "dist/plugins/num/interpreter.d.ts",
@@ -5193,7 +5902,7 @@
           "name": "numInterpreter",
           "variableTypeTokenRange": {
             "startIndex": 1,
-            "endIndex": 2
+            "endIndex": 108
           }
         },
         {

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -24,7 +24,18 @@ export const boolean: PluginDefinition<BooleanMethods, {
 }>;
 
 // @public
-export const booleanInterpreter: Interpreter;
+export const booleanInterpreter: {
+    "boolean/and": (node: BooleanAndNode) => AsyncGenerator<TypedNode<unknown>, boolean, unknown>;
+    "boolean/or": (node: BooleanOrNode) => AsyncGenerator<TypedNode<unknown>, boolean, unknown>;
+    "boolean/not": (node: BooleanNotNode) => AsyncGenerator<TypedNode<unknown>, boolean, unknown>;
+    "boolean/eq": (node: BooleanEqNode) => AsyncGenerator<TypedNode<unknown>, boolean, unknown>;
+    "boolean/ff": (_node: BooleanFalseNode) => AsyncGenerator<never, false, unknown>;
+    "boolean/tt": (_node: BooleanTrueNode) => AsyncGenerator<never, true, unknown>;
+    "boolean/implies": (node: BooleanImpliesNode) => AsyncGenerator<TypedNode<unknown>, boolean, unknown>;
+    "boolean/show": (node: BooleanShowNode) => AsyncGenerator<TypedNode<unknown>, string, unknown>;
+    "boolean/top": (_node: BooleanTopNode) => AsyncGenerator<never, true, unknown>;
+    "boolean/bottom": (_node: BooleanBottomNode) => AsyncGenerator<never, false, unknown>;
+};
 
 // @public
 export type BooleanMethods = {};
@@ -343,7 +354,27 @@ export const num: PluginDefinition<NumMethods, {
 }>;
 
 // @public
-export const numInterpreter: Interpreter;
+export const numInterpreter: {
+    "num/add": (node: NumAddNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/sub": (node: NumSubNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/mul": (node: NumMulNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/div": (node: NumDivNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/mod": (node: NumModNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/compare": (node: NumCompareNode) => AsyncGenerator<TypedNode<unknown>, 1 | 0 | -1, unknown>;
+    "num/neg": (node: NumNegNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/abs": (node: NumAbsNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/floor": (node: NumFloorNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/ceil": (node: NumCeilNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/round": (node: NumRoundNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/min": (node: NumMinNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/max": (node: NumMaxNode) => AsyncGenerator<TypedNode<unknown>, number, unknown>;
+    "num/eq": (node: NumEqNode) => AsyncGenerator<TypedNode<unknown>, boolean, unknown>;
+    "num/zero": (_node: NumZeroNode) => AsyncGenerator<never, number, unknown>;
+    "num/one": (_node: NumOneNode) => AsyncGenerator<never, number, unknown>;
+    "num/show": (node: NumShowNode) => AsyncGenerator<TypedNode<unknown>, string, unknown>;
+    "num/top": (_node: NumTopNode) => AsyncGenerator<never, number, unknown>;
+    "num/bottom": (_node: NumBottomNode) => AsyncGenerator<never, number, unknown>;
+};
 
 // @public
 export interface NumMethods {
@@ -635,7 +666,36 @@ export const VOLATILE_KINDS: Set<string>;
 // dist/builder.d.ts:11:5 - (ae-forgotten-export) The symbol "CoreDollar" needs to be exported by the entry point index.d.ts
 // dist/builder.d.ts:11:5 - (ae-forgotten-export) The symbol "MergePlugins" needs to be exported by the entry point index.d.ts
 // dist/builder.d.ts:11:5 - (ae-forgotten-export) The symbol "FlattenPluginInputs" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:58:5 - (ae-forgotten-export) The symbol "BooleanAndNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:59:5 - (ae-forgotten-export) The symbol "BooleanOrNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:60:5 - (ae-forgotten-export) The symbol "BooleanNotNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:61:5 - (ae-forgotten-export) The symbol "BooleanEqNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:62:5 - (ae-forgotten-export) The symbol "BooleanFalseNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:63:5 - (ae-forgotten-export) The symbol "BooleanTrueNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:64:5 - (ae-forgotten-export) The symbol "BooleanImpliesNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:65:5 - (ae-forgotten-export) The symbol "BooleanShowNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:66:5 - (ae-forgotten-export) The symbol "BooleanTopNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/boolean/interpreter.d.ts:67:5 - (ae-forgotten-export) The symbol "BooleanBottomNode" needs to be exported by the entry point index.d.ts
 // dist/plugins/eq/interpreter.d.ts:13:5 - (ae-forgotten-export) The symbol "EqNeq" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:106:5 - (ae-forgotten-export) The symbol "NumAddNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:107:5 - (ae-forgotten-export) The symbol "NumSubNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:108:5 - (ae-forgotten-export) The symbol "NumMulNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:109:5 - (ae-forgotten-export) The symbol "NumDivNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:110:5 - (ae-forgotten-export) The symbol "NumModNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:111:5 - (ae-forgotten-export) The symbol "NumCompareNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:112:5 - (ae-forgotten-export) The symbol "NumNegNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:113:5 - (ae-forgotten-export) The symbol "NumAbsNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:114:5 - (ae-forgotten-export) The symbol "NumFloorNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:115:5 - (ae-forgotten-export) The symbol "NumCeilNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:116:5 - (ae-forgotten-export) The symbol "NumRoundNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:117:5 - (ae-forgotten-export) The symbol "NumMinNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:118:5 - (ae-forgotten-export) The symbol "NumMaxNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:119:5 - (ae-forgotten-export) The symbol "NumEqNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:120:5 - (ae-forgotten-export) The symbol "NumZeroNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:121:5 - (ae-forgotten-export) The symbol "NumOneNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:122:5 - (ae-forgotten-export) The symbol "NumShowNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:123:5 - (ae-forgotten-export) The symbol "NumTopNode" needs to be exported by the entry point index.d.ts
+// dist/plugins/num/interpreter.d.ts:124:5 - (ae-forgotten-export) The symbol "NumBottomNode" needs to be exported by the entry point index.d.ts
 // dist/plugins/ord/interpreter.d.ts:16:5 - (ae-forgotten-export) The symbol "OrdCmp" needs to be exported by the entry point index.d.ts
 // dist/plugins/str/interpreter.d.ts:104:5 - (ae-forgotten-export) The symbol "StrTemplateNode" needs to be exported by the entry point index.d.ts
 // dist/plugins/str/interpreter.d.ts:105:5 - (ae-forgotten-export) The symbol "StrConcatNode" needs to be exported by the entry point index.d.ts

--- a/packages/core/src/__tests__/node-type-map.type-test.ts
+++ b/packages/core/src/__tests__/node-type-map.type-test.ts
@@ -161,3 +161,35 @@ const _eqWrongType = typedInterpreter<"eq/neq">()({
     return node.operand;
   },
 });
+
+// --- boolean/num registrations ---
+
+const _booleanCorrect = typedInterpreter<"boolean/not">()({
+  // biome-ignore lint/correctness/useYield: type test
+  "boolean/not": async function* (_node) {
+    return true;
+  },
+});
+
+const _numCorrect = typedInterpreter<"num/neg">()({
+  // biome-ignore lint/correctness/useYield: type test
+  "num/neg": async function* (_node) {
+    return 0;
+  },
+});
+
+const _booleanBadAny = typedInterpreter<"boolean/not">()({
+  // @ts-expect-error handler with node:any must be rejected once registered
+  // biome-ignore lint/correctness/useYield: type test
+  "boolean/not": async function* (node: any) {
+    return node.operand;
+  },
+});
+
+const _numBadAny = typedInterpreter<"num/neg">()({
+  // @ts-expect-error handler with node:any must be rejected once registered
+  // biome-ignore lint/correctness/useYield: type test
+  "num/neg": async function* (node: any) {
+    return node.operand;
+  },
+});

--- a/packages/core/src/plugins/boolean/interpreter.ts
+++ b/packages/core/src/plugins/boolean/interpreter.ts
@@ -1,56 +1,124 @@
-import type { Interpreter, TypedNode } from "../../fold";
-import { eval_ } from "../../fold";
+import type { TypedNode } from "../../fold";
+import { eval_, typedInterpreter } from "../../fold";
 
 // ---- Typed node interfaces ----------------------------------
 
-interface BoolBinOp extends TypedNode<boolean> {
+export interface BooleanAndNode extends TypedNode<boolean> {
+  kind: "boolean/and";
   left: TypedNode<boolean>;
   right: TypedNode<boolean>;
 }
 
-interface BoolUnary extends TypedNode<boolean> {
+export interface BooleanOrNode extends TypedNode<boolean> {
+  kind: "boolean/or";
+  left: TypedNode<boolean>;
+  right: TypedNode<boolean>;
+}
+
+export interface BooleanNotNode extends TypedNode<boolean> {
+  kind: "boolean/not";
   operand: TypedNode<boolean>;
 }
+
+export interface BooleanEqNode extends TypedNode<boolean> {
+  kind: "boolean/eq";
+  left: TypedNode<boolean>;
+  right: TypedNode<boolean>;
+}
+
+export interface BooleanFalseNode extends TypedNode<boolean> {
+  kind: "boolean/ff";
+}
+
+export interface BooleanTrueNode extends TypedNode<boolean> {
+  kind: "boolean/tt";
+}
+
+export interface BooleanImpliesNode extends TypedNode<boolean> {
+  kind: "boolean/implies";
+  left: TypedNode<boolean>;
+  right: TypedNode<boolean>;
+}
+
+export interface BooleanShowNode extends TypedNode<string> {
+  kind: "boolean/show";
+  operand: TypedNode<boolean>;
+}
+
+export interface BooleanTopNode extends TypedNode<boolean> {
+  kind: "boolean/top";
+}
+
+export interface BooleanBottomNode extends TypedNode<boolean> {
+  kind: "boolean/bottom";
+}
+
+declare module "@mvfm/core" {
+  interface NodeTypeMap {
+    "boolean/and": BooleanAndNode;
+    "boolean/or": BooleanOrNode;
+    "boolean/not": BooleanNotNode;
+    "boolean/eq": BooleanEqNode;
+    "boolean/ff": BooleanFalseNode;
+    "boolean/tt": BooleanTrueNode;
+    "boolean/implies": BooleanImpliesNode;
+    "boolean/show": BooleanShowNode;
+    "boolean/top": BooleanTopNode;
+    "boolean/bottom": BooleanBottomNode;
+  }
+}
+
+type BooleanKinds =
+  | "boolean/and"
+  | "boolean/or"
+  | "boolean/not"
+  | "boolean/eq"
+  | "boolean/ff"
+  | "boolean/tt"
+  | "boolean/implies"
+  | "boolean/show"
+  | "boolean/top"
+  | "boolean/bottom";
 
 // ---- Interpreter map ----------------------------------------
 
 /** Interpreter handlers for `boolean/` node kinds. */
-export const booleanInterpreter: Interpreter = {
-  "boolean/and": async function* (node: BoolBinOp) {
+export const booleanInterpreter = typedInterpreter<BooleanKinds>()({
+  "boolean/and": async function* (node: BooleanAndNode) {
     const left = yield* eval_(node.left);
     return left ? yield* eval_(node.right) : false;
   },
-  "boolean/or": async function* (node: BoolBinOp) {
+  "boolean/or": async function* (node: BooleanOrNode) {
     const left = yield* eval_(node.left);
     return left ? true : yield* eval_(node.right);
   },
-  "boolean/not": async function* (node: BoolUnary) {
+  "boolean/not": async function* (node: BooleanNotNode) {
     return !(yield* eval_(node.operand));
   },
-  "boolean/eq": async function* (node: BoolBinOp) {
+  "boolean/eq": async function* (node: BooleanEqNode) {
     return (yield* eval_(node.left)) === (yield* eval_(node.right));
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "boolean/ff": async function* () {
+  "boolean/ff": async function* (_node: BooleanFalseNode) {
     return false;
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "boolean/tt": async function* () {
+  "boolean/tt": async function* (_node: BooleanTrueNode) {
     return true;
   },
-  "boolean/implies": async function* (node: BoolBinOp) {
+  "boolean/implies": async function* (node: BooleanImpliesNode) {
     const left = yield* eval_(node.left);
     return !left ? true : yield* eval_(node.right);
   },
-  "boolean/show": async function* (node: BoolUnary) {
+  "boolean/show": async function* (node: BooleanShowNode) {
     return String(yield* eval_(node.operand));
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "boolean/top": async function* () {
+  "boolean/top": async function* (_node: BooleanTopNode) {
     return true;
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "boolean/bottom": async function* () {
+  "boolean/bottom": async function* (_node: BooleanBottomNode) {
     return false;
   },
-};
+});

--- a/packages/core/src/plugins/num/interpreter.ts
+++ b/packages/core/src/plugins/num/interpreter.ts
@@ -1,90 +1,220 @@
-import type { Interpreter, TypedNode } from "../../fold";
-import { eval_ } from "../../fold";
+import type { TypedNode } from "../../fold";
+import { eval_, typedInterpreter } from "../../fold";
 
 // ---- Typed node interfaces ----------------------------------
 
-interface NumBinOp extends TypedNode<number> {
+export interface NumAddNode extends TypedNode<number> {
+  kind: "num/add";
   left: TypedNode<number>;
   right: TypedNode<number>;
 }
 
-interface NumUnaryOp extends TypedNode<number> {
+export interface NumSubNode extends TypedNode<number> {
+  kind: "num/sub";
+  left: TypedNode<number>;
+  right: TypedNode<number>;
+}
+
+export interface NumMulNode extends TypedNode<number> {
+  kind: "num/mul";
+  left: TypedNode<number>;
+  right: TypedNode<number>;
+}
+
+export interface NumDivNode extends TypedNode<number> {
+  kind: "num/div";
+  left: TypedNode<number>;
+  right: TypedNode<number>;
+}
+
+export interface NumModNode extends TypedNode<number> {
+  kind: "num/mod";
+  left: TypedNode<number>;
+  right: TypedNode<number>;
+}
+
+export interface NumCompareNode extends TypedNode<number> {
+  kind: "num/compare";
+  left: TypedNode<number>;
+  right: TypedNode<number>;
+}
+
+export interface NumNegNode extends TypedNode<number> {
+  kind: "num/neg";
   operand: TypedNode<number>;
 }
 
-interface NumVariadic extends TypedNode<number> {
+export interface NumAbsNode extends TypedNode<number> {
+  kind: "num/abs";
+  operand: TypedNode<number>;
+}
+
+export interface NumFloorNode extends TypedNode<number> {
+  kind: "num/floor";
+  operand: TypedNode<number>;
+}
+
+export interface NumCeilNode extends TypedNode<number> {
+  kind: "num/ceil";
+  operand: TypedNode<number>;
+}
+
+export interface NumRoundNode extends TypedNode<number> {
+  kind: "num/round";
+  operand: TypedNode<number>;
+}
+
+export interface NumMinNode extends TypedNode<number> {
+  kind: "num/min";
   values: TypedNode<number>[];
 }
+
+export interface NumMaxNode extends TypedNode<number> {
+  kind: "num/max";
+  values: TypedNode<number>[];
+}
+
+export interface NumEqNode extends TypedNode<boolean> {
+  kind: "num/eq";
+  left: TypedNode<number>;
+  right: TypedNode<number>;
+}
+
+export interface NumZeroNode extends TypedNode<number> {
+  kind: "num/zero";
+}
+
+export interface NumOneNode extends TypedNode<number> {
+  kind: "num/one";
+}
+
+export interface NumShowNode extends TypedNode<string> {
+  kind: "num/show";
+  operand: TypedNode<number>;
+}
+
+export interface NumTopNode extends TypedNode<number> {
+  kind: "num/top";
+}
+
+export interface NumBottomNode extends TypedNode<number> {
+  kind: "num/bottom";
+}
+
+declare module "@mvfm/core" {
+  interface NodeTypeMap {
+    "num/add": NumAddNode;
+    "num/sub": NumSubNode;
+    "num/mul": NumMulNode;
+    "num/div": NumDivNode;
+    "num/mod": NumModNode;
+    "num/compare": NumCompareNode;
+    "num/neg": NumNegNode;
+    "num/abs": NumAbsNode;
+    "num/floor": NumFloorNode;
+    "num/ceil": NumCeilNode;
+    "num/round": NumRoundNode;
+    "num/min": NumMinNode;
+    "num/max": NumMaxNode;
+    "num/eq": NumEqNode;
+    "num/zero": NumZeroNode;
+    "num/one": NumOneNode;
+    "num/show": NumShowNode;
+    "num/top": NumTopNode;
+    "num/bottom": NumBottomNode;
+  }
+}
+
+type NumKinds =
+  | "num/add"
+  | "num/sub"
+  | "num/mul"
+  | "num/div"
+  | "num/mod"
+  | "num/compare"
+  | "num/neg"
+  | "num/abs"
+  | "num/floor"
+  | "num/ceil"
+  | "num/round"
+  | "num/min"
+  | "num/max"
+  | "num/eq"
+  | "num/zero"
+  | "num/one"
+  | "num/show"
+  | "num/top"
+  | "num/bottom";
 
 // ---- Interpreter map ----------------------------------------
 
 /** Interpreter handlers for `num/` node kinds. */
-export const numInterpreter: Interpreter = {
-  "num/add": async function* (node: NumBinOp) {
+export const numInterpreter = typedInterpreter<NumKinds>()({
+  "num/add": async function* (node: NumAddNode) {
     return (yield* eval_(node.left)) + (yield* eval_(node.right));
   },
-  "num/sub": async function* (node: NumBinOp) {
+  "num/sub": async function* (node: NumSubNode) {
     return (yield* eval_(node.left)) - (yield* eval_(node.right));
   },
-  "num/mul": async function* (node: NumBinOp) {
+  "num/mul": async function* (node: NumMulNode) {
     return (yield* eval_(node.left)) * (yield* eval_(node.right));
   },
-  "num/div": async function* (node: NumBinOp) {
+  "num/div": async function* (node: NumDivNode) {
     return (yield* eval_(node.left)) / (yield* eval_(node.right));
   },
-  "num/mod": async function* (node: NumBinOp) {
+  "num/mod": async function* (node: NumModNode) {
     return (yield* eval_(node.left)) % (yield* eval_(node.right));
   },
-  "num/compare": async function* (node: NumBinOp) {
+  "num/compare": async function* (node: NumCompareNode) {
     const l = yield* eval_(node.left);
     const r = yield* eval_(node.right);
     return l < r ? -1 : l === r ? 0 : 1;
   },
-  "num/neg": async function* (node: NumUnaryOp) {
+  "num/neg": async function* (node: NumNegNode) {
     return -(yield* eval_(node.operand));
   },
-  "num/abs": async function* (node: NumUnaryOp) {
+  "num/abs": async function* (node: NumAbsNode) {
     return Math.abs(yield* eval_(node.operand));
   },
-  "num/floor": async function* (node: NumUnaryOp) {
+  "num/floor": async function* (node: NumFloorNode) {
     return Math.floor(yield* eval_(node.operand));
   },
-  "num/ceil": async function* (node: NumUnaryOp) {
+  "num/ceil": async function* (node: NumCeilNode) {
     return Math.ceil(yield* eval_(node.operand));
   },
-  "num/round": async function* (node: NumUnaryOp) {
+  "num/round": async function* (node: NumRoundNode) {
     return Math.round(yield* eval_(node.operand));
   },
-  "num/min": async function* (node: NumVariadic) {
+  "num/min": async function* (node: NumMinNode) {
     const values: number[] = [];
     for (const v of node.values) values.push(yield* eval_(v));
     return Math.min(...values);
   },
-  "num/max": async function* (node: NumVariadic) {
+  "num/max": async function* (node: NumMaxNode) {
     const values: number[] = [];
     for (const v of node.values) values.push(yield* eval_(v));
     return Math.max(...values);
   },
-  "num/eq": async function* (node: NumBinOp) {
+  "num/eq": async function* (node: NumEqNode) {
     return (yield* eval_(node.left)) === (yield* eval_(node.right));
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "num/zero": async function* () {
+  "num/zero": async function* (_node: NumZeroNode) {
     return 0;
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "num/one": async function* () {
+  "num/one": async function* (_node: NumOneNode) {
     return 1;
   },
-  "num/show": async function* (node: NumUnaryOp) {
+  "num/show": async function* (node: NumShowNode) {
     return String(yield* eval_(node.operand));
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "num/top": async function* () {
+  "num/top": async function* (_node: NumTopNode) {
     return Infinity;
   },
   // biome-ignore lint/correctness/useYield: leaf handler
-  "num/bottom": async function* () {
+  "num/bottom": async function* (_node: NumBottomNode) {
     return -Infinity;
   },
-};
+});


### PR DESCRIPTION
Closes #210

## What this does

This updates the core `boolean` and `num` interpreters to use `typedInterpreter` with explicit typed node interfaces per node kind. It also registers all `boolean/*` and `num/*` kinds into `NodeTypeMap` via `declare module "@mvfm/core"` augmentation so handler node parameters are checked at compile time. Finally, it adds representative compile-time assertions for these new registrations in `node-type-map.type-test.ts`.

## Design alignment

- **Deterministic, inspectable AST contracts:** each boolean/num node kind now has an explicit typed interface, and all are registered in `NodeTypeMap` for compile-time contract enforcement.
- **Plugin contract alignment (`name`, `nodeKinds`, `build(ctx)`):** plugin definitions remain unchanged; only interpreter typing and node-kind registration were hardened.
- **No behavior drift:** runtime interpreter logic for boolean/num operations is unchanged; changes are type-safety-only.

No deviations requiring a `spec-change` issue.

## Validation performed

- `npm run build` (pass)
- `npm run check` (pass)
- `npm test` (fails in this environment due missing container runtime for postgres integration tests)
  - failure evidence: `@mvfm/plugin-postgres` cannot start `testcontainers` (`Could not find a working container runtime strategy`)
- Focused package verification for touched code:
  - `pnpm --filter @mvfm/core run test` (pass: 40 files, 352 tests)
