### PR TITLE
Add typed node interfaces for anthropic/openai and register NodeTypeMap

### DIFF
--- a/docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-design.md
+++ b/docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-design.md
@@ -1,0 +1,51 @@
+# Issue #212: Typed Node Interfaces for anthropic/openai
+
+**Issue:** #212  
+**Date:** 2026-02-17  
+**Status:** Design approved
+
+## Scope
+
+Add typed node interfaces and `NodeTypeMap` registrations for all node kinds handled by:
+- `packages/plugin-anthropic/src/0.74.0/interpreter.ts`
+- `packages/plugin-openai/src/6.21.0/interpreter.ts`
+
+Strict scope: interpreter typing only (`typedInterpreter`, typed node interfaces, `NodeTypeMap` augmentation). No plugin API changes.
+
+## Architecture
+
+For each plugin interpreter file:
+1. Replace generic catch-all node interface with one exported interface per handled node kind.
+2. Add `declare module "@mvfm/core"` augmentation to register every kind in `NodeTypeMap`.
+3. Replace raw `Interpreter` object literal with `typedInterpreter<...>()({ ... })`.
+
+This aligns with the typed-handler pattern established in #197 and used in typed plugin interpreters (for example postgres/redis).
+
+## Type and Data Flow
+
+`typedInterpreter` will enforce, at compile time, that each registered kind:
+- has a handler,
+- uses the correct node parameter type,
+- cannot use `node: any` for registered kinds,
+- returns a value compatible with the node phantom type.
+
+For optional params/list APIs, node shapes will encode `params` as nullable/optional node references to match current runtime behavior.
+
+## Testing and Validation
+
+Use TDD at compile-time level:
+- Add failing type tests under each plugin `src/__tests__/` folder that assert the new registrations are enforced (including `node:any` rejection).
+- Run package build in RED state to confirm failure before implementation.
+- Implement minimal typing changes in both interpreters.
+- Re-run package build/check/tests, then repo-required verification commands:
+  - `npm run build`
+  - `npm run check`
+  - `npm test`
+
+Note: baseline workspace currently has unrelated recursive test failures in some plugin test packages due unresolved `@mvfm/core` entry; these will be reported if still present.
+
+## Not in Scope
+
+- Runtime behavior changes in anthropic/openai handlers.
+- Plugin builder method signature changes.
+- New operations/resources beyond the node kinds listed in issue #212.

--- a/docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-implementation-plan.md
+++ b/docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-implementation-plan.md
@@ -1,0 +1,124 @@
+# Issue #212 AI Plugin Typed Nodes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enforce typed handler node parameters for all targeted `anthropic/*` and `openai/*` interpreter kinds via `NodeTypeMap` + `typedInterpreter`.
+
+**Architecture:** Keep typing local to each affected interpreter file. Export node interfaces, augment `NodeTypeMap` in each plugin interpreter, and replace raw handler maps with `typedInterpreter` builders.
+
+**Tech Stack:** TypeScript, module augmentation, `typedInterpreter`, tsc compile-time tests.
+
+---
+
+### Task 1: Add failing compile-time tests for anthropic/openai registrations
+
+**Files:**
+- Create: `packages/plugin-anthropic/src/__tests__/node-type-map.type-test.ts`
+- Create: `packages/plugin-openai/src/__tests__/node-type-map.type-test.ts`
+
+**Step 1: Write failing type tests**
+
+Add compile-time tests with `@ts-expect-error` that expect `node:any` to be rejected for registered kinds (which should fail before registration exists).
+
+**Step 2: Run test command to verify RED**
+
+Run:
+- `pnpm --filter @mvfm/plugin-anthropic run build`
+- `pnpm --filter @mvfm/plugin-openai run build`
+
+Expected: FAIL due unused `@ts-expect-error` before interpreter registration typing is added.
+
+### Task 2: Type and register all anthropic interpreter kinds
+
+**Files:**
+- Modify: `packages/plugin-anthropic/src/0.74.0/interpreter.ts`
+
+**Step 1: Export typed node interfaces**
+
+Add exported node interfaces for:
+- `anthropic/create_message`
+- `anthropic/count_tokens`
+- `anthropic/create_message_batch`
+- `anthropic/retrieve_message_batch`
+- `anthropic/list_message_batches`
+- `anthropic/delete_message_batch`
+- `anthropic/cancel_message_batch`
+- `anthropic/retrieve_model`
+- `anthropic/list_models`
+
+**Step 2: Add `NodeTypeMap` augmentation**
+
+Register all listed `anthropic/*` kinds via `declare module "@mvfm/core"`.
+
+**Step 3: Switch to typed interpreter builder**
+
+Replace raw object return with `typedInterpreter<...>()({ ... })` and typed handler params.
+
+**Step 4: Verify GREEN for anthropic build**
+
+Run: `pnpm --filter @mvfm/plugin-anthropic run build`
+Expected: PASS.
+
+### Task 3: Type and register all openai interpreter kinds
+
+**Files:**
+- Modify: `packages/plugin-openai/src/6.21.0/interpreter.ts`
+
+**Step 1: Export typed node interfaces**
+
+Add exported node interfaces for:
+- `openai/create_chat_completion`
+- `openai/retrieve_chat_completion`
+- `openai/list_chat_completions`
+- `openai/update_chat_completion`
+- `openai/delete_chat_completion`
+- `openai/create_embedding`
+- `openai/create_moderation`
+- `openai/create_completion`
+
+**Step 2: Add `NodeTypeMap` augmentation**
+
+Register all listed `openai/*` kinds via `declare module "@mvfm/core"`.
+
+**Step 3: Switch to typed interpreter builder**
+
+Replace raw object return with `typedInterpreter<...>()({ ... })` and typed handler params.
+
+**Step 4: Verify GREEN for openai build**
+
+Run: `pnpm --filter @mvfm/plugin-openai run build`
+Expected: PASS.
+
+### Task 4: Full verification and commit
+
+**Files:**
+- Create: `docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-design.md`
+- Create: `docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-implementation-plan.md`
+- Create: `packages/plugin-anthropic/src/__tests__/node-type-map.type-test.ts`
+- Create: `packages/plugin-openai/src/__tests__/node-type-map.type-test.ts`
+- Modify: `packages/plugin-anthropic/src/0.74.0/interpreter.ts`
+- Modify: `packages/plugin-openai/src/6.21.0/interpreter.ts`
+
+**Step 1: Run required project verification**
+
+Run:
+- `npm run build`
+- `npm run check`
+- `npm test`
+
+Expected:
+- build/check pass,
+- report any pre-existing unrelated test failures if present.
+
+**Step 2: Commit implementation**
+
+Run:
+```bash
+git add docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-design.md \
+        docs/plans/2026-02-17-issue-212-ai-plugin-typed-nodes-implementation-plan.md \
+        packages/plugin-anthropic/src/__tests__/node-type-map.type-test.ts \
+        packages/plugin-openai/src/__tests__/node-type-map.type-test.ts \
+        packages/plugin-anthropic/src/0.74.0/interpreter.ts \
+        packages/plugin-openai/src/6.21.0/interpreter.ts
+git commit -m "feat(plugins): type and register anthropic/openai interpreter node kinds"
+```

--- a/packages/plugin-anthropic/src/__tests__/node-type-map.type-test.ts
+++ b/packages/plugin-anthropic/src/__tests__/node-type-map.type-test.ts
@@ -1,0 +1,32 @@
+import { typedInterpreter } from "@mvfm/core";
+import type { AnthropicCountTokensNode, AnthropicCreateMessageNode } from "../0.74.0/interpreter";
+
+// Positive: registered kind with correct node type compiles.
+const _positive = typedInterpreter<"anthropic/create_message">()({
+  // biome-ignore lint/correctness/useYield: type-only compile test
+  "anthropic/create_message": async function* (node: AnthropicCreateMessageNode) {
+    return node.params;
+  },
+});
+
+// Negative: node:any must be rejected for registered kinds.
+const _badAny = typedInterpreter<"anthropic/create_message">()({
+  // @ts-expect-error node:any must be rejected for registered anthropic kinds
+  // biome-ignore lint/correctness/useYield: type-only compile test
+  "anthropic/create_message": async function* (node: any) {
+    return node;
+  },
+});
+
+// Negative: wrong node interface must be rejected.
+const _wrongType = typedInterpreter<"anthropic/create_message">()({
+  // @ts-expect-error wrong node interface for anthropic/create_message
+  // biome-ignore lint/correctness/useYield: type-only compile test
+  "anthropic/create_message": async function* (node: AnthropicCountTokensNode) {
+    return node.params;
+  },
+});
+
+void _positive;
+void _badAny;
+void _wrongType;

--- a/packages/plugin-openai/src/__tests__/node-type-map.type-test.ts
+++ b/packages/plugin-openai/src/__tests__/node-type-map.type-test.ts
@@ -1,0 +1,35 @@
+import { typedInterpreter } from "@mvfm/core";
+import type {
+  OpenAICreateChatCompletionNode,
+  OpenAICreateEmbeddingNode,
+} from "../6.21.0/interpreter";
+
+// Positive: registered kind with correct node type compiles.
+const _positive = typedInterpreter<"openai/create_chat_completion">()({
+  // biome-ignore lint/correctness/useYield: type-only compile test
+  "openai/create_chat_completion": async function* (node: OpenAICreateChatCompletionNode) {
+    return node.params;
+  },
+});
+
+// Negative: node:any must be rejected for registered kinds.
+const _badAny = typedInterpreter<"openai/create_chat_completion">()({
+  // @ts-expect-error node:any must be rejected for registered openai kinds
+  // biome-ignore lint/correctness/useYield: type-only compile test
+  "openai/create_chat_completion": async function* (node: any) {
+    return node;
+  },
+});
+
+// Negative: wrong node interface must be rejected.
+const _wrongType = typedInterpreter<"openai/create_chat_completion">()({
+  // @ts-expect-error wrong node interface for openai/create_chat_completion
+  // biome-ignore lint/correctness/useYield: type-only compile test
+  "openai/create_chat_completion": async function* (node: OpenAICreateEmbeddingNode) {
+    return node.params;
+  },
+});
+
+void _positive;
+void _badAny;
+void _wrongType;


### PR DESCRIPTION
Closes #212

## What this does
This PR adds per-kind typed node interfaces for all `anthropic/*` and `openai/*` interpreter handlers and registers them in `NodeTypeMap` via module augmentation. It switches both interpreters to `typedInterpreter<...>()` so handler signatures are compile-time enforced for the registered node kinds. Runtime behavior and plugin builder APIs are unchanged.

## Design alignment
Issue #212 does not cite specific VISION.md principles by name. This implementation aligns with Phase 1 core solidification by tightening interpreter type contracts without changing AST semantics or runtime execution behavior.

## Validation performed
- `npm run build` ✅ pass
- `npm run check` ✅ pass
- `npm test` ⚠️ fails in this environment due unrelated infrastructure constraints:
  - `@mvfm/plugin-postgres` integration suites require a container runtime (`Could not find a working container runtime strategy`)
  - `@mvfm/plugin-openai` integration suites require localhost bind permissions (`listen EPERM 127.0.0.1`)
- Focused package checks for this change:
  - `pnpm --filter @mvfm/plugin-anthropic run check` ✅ pass
  - `pnpm --filter @mvfm/plugin-openai run check` ✅ pass
  - `pnpm --filter @mvfm/plugin-anthropic run test` ✅ pass
