### PR TITLE
Add typed node interfaces for fetch, s3, and cloudflare-kv plugins

### DIFF
--- a/docs/plans/2026-02-17-issue-213-typed-data-plugins-design.md
+++ b/docs/plans/2026-02-17-issue-213-typed-data-plugins-design.md
@@ -1,0 +1,42 @@
+# Issue 213 Typed Data Plugin Nodes Design
+
+## Goal
+Add concrete typed node interfaces and `NodeTypeMap` registration for `fetch/*`, `s3/*`, and `cloudflare-kv/*` node kinds, then enforce handler typing via `typedInterpreter` in each plugin interpreter.
+
+## Scope
+- In scope:
+  - `packages/plugin-fetch/src/whatwg/interpreter.ts`
+  - `packages/plugin-s3/src/3.989.0/interpreter.ts`
+  - `packages/plugin-cloudflare-kv/src/4.20260213.0/interpreter.ts`
+  - Compile-time type test files under each plugin `src/` tree
+- Not in scope:
+  - Runtime behavior changes
+  - API surface expansion beyond listed node kinds
+  - Moving interfaces to new `nodes.ts` modules
+
+## Architecture
+Use the existing interpreter files as the canonical home for typed node interfaces and module augmentation, matching current `plugin-postgres` style:
+- Export a typed interface per node kind.
+- Add `declare module "@mvfm/core" { interface NodeTypeMap { ... } }` for each kind.
+- Replace untyped interpreter objects with `typedInterpreter<KindUnion>()({...})`.
+
+## Data Flow
+Data flow remains unchanged. Only TypeScript compile-time constraints change:
+- Handler node params become strongly typed.
+- Return types are validated against each node interface `TypedNode<T>` phantom type.
+- Missing/wrong handler signatures fail at compile time.
+
+## Error Handling
+No runtime logic is added. Existing runtime error paths remain:
+- `s3` unknown-kind guard remains in place.
+- `fetch` and `cloudflare-kv` operation behavior remains as-is.
+
+## Testing
+Add compile-time-only type tests in each plugin `src/__tests__/` tree to validate:
+- Positive: typed handlers compile.
+- Negative: `@ts-expect-error` catches `any` and wrong node parameter types for registered kinds.
+
+Validation commands after implementation:
+- `pnpm build`
+- `pnpm check`
+- `pnpm test`

--- a/docs/plans/2026-02-17-issue-213-typed-data-plugins-plan.md
+++ b/docs/plans/2026-02-17-issue-213-typed-data-plugins-plan.md
@@ -1,0 +1,54 @@
+# Issue 213 Typed Data Plugins Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add typed node interfaces + `NodeTypeMap` registration and `typedInterpreter` enforcement for fetch, s3, and cloudflare-kv interpreters, with compile-time type tests.
+
+**Architecture:** Keep typed node definitions local to each plugin `interpreter.ts`, add module augmentation there, and migrate each interpreter factory to `typedInterpreter<...>()`. Add compile-time tests under plugin `src/__tests__` to enforce handler typing for the newly registered kinds.
+
+**Tech Stack:** TypeScript, `@mvfm/core` typed interpreter APIs, pnpm workspace build/check/test.
+
+---
+
+### Task 1: Type fetch interpreter
+
+**Files:**
+- Modify: `packages/plugin-fetch/src/whatwg/interpreter.ts`
+- Test: `packages/plugin-fetch/src/__tests__/node-type-map.type-test.ts`
+
+1. Add exported interfaces for `fetch/request`, `fetch/json`, `fetch/text`, `fetch/status`, `fetch/headers`.
+2. Add `declare module "@mvfm/core"` `NodeTypeMap` entries for those kinds.
+3. Replace object-literal interpreter return with `typedInterpreter<FetchKind>()({...})`.
+4. Add compile-time type tests with positive and `@ts-expect-error` negative cases.
+
+### Task 2: Type s3 interpreter
+
+**Files:**
+- Modify: `packages/plugin-s3/src/3.989.0/interpreter.ts`
+- Test: `packages/plugin-s3/src/__tests__/node-type-map.type-test.ts`
+
+1. Add exported interfaces for each `s3/*` kind in issue scope.
+2. Add `NodeTypeMap` augmentation.
+3. Use `typedInterpreter<S3Kind>()({...})` and keep current command dispatch logic.
+4. Add compile-time type tests for correct and incorrect handler node parameter types.
+
+### Task 3: Type cloudflare-kv interpreter
+
+**Files:**
+- Modify: `packages/plugin-cloudflare-kv/src/4.20260213.0/interpreter.ts`
+- Test: `packages/plugin-cloudflare-kv/src/__tests__/node-type-map.type-test.ts`
+
+1. Add exported interfaces for each `cloudflare-kv/*` kind in issue scope.
+2. Add `NodeTypeMap` augmentation.
+3. Switch to `typedInterpreter<CloudflareKvKind>()({...})`.
+4. Add compile-time type tests for positive and negative cases.
+
+### Task 4: Validate workspace
+
+**Files:**
+- Verify: all modified files
+
+1. Run `pnpm build`.
+2. Run `pnpm check`.
+3. Run `pnpm test`.
+4. Confirm no unintended file changes and capture outputs for PR notes.

--- a/packages/plugin-cloudflare-kv/src/4.20260213.0/interpreter.ts
+++ b/packages/plugin-cloudflare-kv/src/4.20260213.0/interpreter.ts
@@ -1,5 +1,5 @@
 import type { Interpreter, TypedNode } from "@mvfm/core";
-import { eval_ } from "@mvfm/core";
+import { eval_, typedInterpreter } from "@mvfm/core";
 
 /**
  * Cloudflare KV client interface consumed by the handler.
@@ -28,12 +28,63 @@ export interface CloudflareKvClient {
   }>;
 }
 
-interface KvNode extends TypedNode<unknown> {
-  kind: string;
-  key?: TypedNode<string>;
-  value?: TypedNode<string>;
-  options?: TypedNode;
+/** A `cloudflare-kv/get` node for text retrieval. */
+export interface CloudflareKvGetNode extends TypedNode<string | null> {
+  kind: "cloudflare-kv/get";
+  key: TypedNode<string>;
   config: { namespaceId: string };
+}
+
+/** A `cloudflare-kv/get_json` node for JSON retrieval. */
+export interface CloudflareKvGetJsonNode extends TypedNode<unknown | null> {
+  kind: "cloudflare-kv/get_json";
+  key: TypedNode<string>;
+  config: { namespaceId: string };
+}
+
+/** A `cloudflare-kv/put` node for value writes. */
+export interface CloudflareKvPutNode extends TypedNode<void> {
+  kind: "cloudflare-kv/put";
+  key: TypedNode<string>;
+  value: TypedNode<string>;
+  options?: TypedNode<unknown> | null;
+  config: { namespaceId: string };
+}
+
+/** A `cloudflare-kv/delete` node for key deletion. */
+export interface CloudflareKvDeleteNode extends TypedNode<void> {
+  kind: "cloudflare-kv/delete";
+  key: TypedNode<string>;
+  config: { namespaceId: string };
+}
+
+/** A `cloudflare-kv/list` node for key listing. */
+export interface CloudflareKvListNode
+  extends TypedNode<{
+    keys: Array<{ name: string; expiration?: number }>;
+    list_complete: boolean;
+    cursor?: string;
+  }> {
+  kind: "cloudflare-kv/list";
+  options?: TypedNode<unknown> | null;
+  config: { namespaceId: string };
+}
+
+type CloudflareKvKind =
+  | "cloudflare-kv/get"
+  | "cloudflare-kv/get_json"
+  | "cloudflare-kv/put"
+  | "cloudflare-kv/delete"
+  | "cloudflare-kv/list";
+
+declare module "@mvfm/core" {
+  interface NodeTypeMap {
+    "cloudflare-kv/get": CloudflareKvGetNode;
+    "cloudflare-kv/get_json": CloudflareKvGetJsonNode;
+    "cloudflare-kv/put": CloudflareKvPutNode;
+    "cloudflare-kv/delete": CloudflareKvDeleteNode;
+    "cloudflare-kv/list": CloudflareKvListNode;
+  }
 }
 
 /**
@@ -43,34 +94,34 @@ interface KvNode extends TypedNode<unknown> {
  * @returns An Interpreter handling all cloudflare-kv node kinds.
  */
 export function createCloudflareKvInterpreter(client: CloudflareKvClient): Interpreter {
-  return {
-    "cloudflare-kv/get": async function* (node: KvNode) {
-      const key = yield* eval_(node.key!);
+  return typedInterpreter<CloudflareKvKind>()({
+    "cloudflare-kv/get": async function* (node: CloudflareKvGetNode) {
+      const key = yield* eval_(node.key);
       return await client.get(key);
     },
 
-    "cloudflare-kv/get_json": async function* (node: KvNode) {
-      const key = yield* eval_(node.key!);
+    "cloudflare-kv/get_json": async function* (node: CloudflareKvGetJsonNode) {
+      const key = yield* eval_(node.key);
       return await client.getJson(key);
     },
 
-    "cloudflare-kv/put": async function* (node: KvNode) {
-      const key = yield* eval_(node.key!);
-      const value = yield* eval_(node.value!);
+    "cloudflare-kv/put": async function* (node: CloudflareKvPutNode) {
+      const key = yield* eval_(node.key);
+      const value = yield* eval_(node.value);
       const options = node.options != null ? yield* eval_(node.options) : undefined;
       await client.put(key, value, options as any);
       return undefined;
     },
 
-    "cloudflare-kv/delete": async function* (node: KvNode) {
-      const key = yield* eval_(node.key!);
+    "cloudflare-kv/delete": async function* (node: CloudflareKvDeleteNode) {
+      const key = yield* eval_(node.key);
       await client.delete(key);
       return undefined;
     },
 
-    "cloudflare-kv/list": async function* (node: KvNode) {
+    "cloudflare-kv/list": async function* (node: CloudflareKvListNode) {
       const options = node.options != null ? yield* eval_(node.options) : undefined;
       return await client.list(options as any);
     },
-  };
+  });
 }

--- a/packages/plugin-cloudflare-kv/src/__tests__/node-type-map.type-test.ts
+++ b/packages/plugin-cloudflare-kv/src/__tests__/node-type-map.type-test.ts
@@ -1,0 +1,34 @@
+import type { TypedNode } from "@mvfm/core";
+import { typedInterpreter } from "@mvfm/core";
+import type { CloudflareKvGetNode, CloudflareKvListNode } from "../4.20260213.0/interpreter";
+
+const _kvPositive = typedInterpreter<"cloudflare-kv/get" | "cloudflare-kv/list">()({
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "cloudflare-kv/get": async function* (_node: CloudflareKvGetNode) {
+    return null;
+  },
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "cloudflare-kv/list": async function* (_node: CloudflareKvListNode) {
+    return { keys: [], list_complete: true };
+  },
+});
+
+const _kvBadAny = typedInterpreter<"cloudflare-kv/get">()({
+  // @ts-expect-error registered kind cannot use any node parameter
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "cloudflare-kv/get": async function* (_node: any) {
+    return null;
+  },
+});
+
+interface WrongKvNode extends TypedNode<number> {
+  kind: "cloudflare-kv/list";
+}
+
+const _kvBadNode = typedInterpreter<"cloudflare-kv/list">()({
+  // @ts-expect-error wrong node shape for cloudflare-kv/list
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "cloudflare-kv/list": async function* (_node: WrongKvNode) {
+    return 1;
+  },
+});

--- a/packages/plugin-fetch/src/__tests__/node-type-map.type-test.ts
+++ b/packages/plugin-fetch/src/__tests__/node-type-map.type-test.ts
@@ -1,0 +1,34 @@
+import type { TypedNode } from "@mvfm/core";
+import { typedInterpreter } from "@mvfm/core";
+import type { FetchHeadersNode, FetchRequestNode } from "../whatwg/interpreter";
+
+const _fetchPositive = typedInterpreter<"fetch/request" | "fetch/headers">()({
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "fetch/request": async function* (_node: FetchRequestNode) {
+    return new Response();
+  },
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "fetch/headers": async function* (_node: FetchHeadersNode) {
+    return {};
+  },
+});
+
+const _fetchBadAny = typedInterpreter<"fetch/request">()({
+  // @ts-expect-error registered kind cannot use any node parameter
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "fetch/request": async function* (_node: any) {
+    return new Response();
+  },
+});
+
+interface WrongFetchNode extends TypedNode<number> {
+  kind: "fetch/request";
+}
+
+const _fetchBadNode = typedInterpreter<"fetch/request">()({
+  // @ts-expect-error wrong node shape for fetch/request
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "fetch/request": async function* (_node: WrongFetchNode) {
+    return 1;
+  },
+});

--- a/packages/plugin-s3/src/3.989.0/interpreter.ts
+++ b/packages/plugin-s3/src/3.989.0/interpreter.ts
@@ -1,5 +1,17 @@
+import type {
+  DeleteObjectCommandInput,
+  DeleteObjectCommandOutput,
+  GetObjectCommandInput,
+  GetObjectCommandOutput,
+  HeadObjectCommandInput,
+  HeadObjectCommandOutput,
+  ListObjectsV2CommandInput,
+  ListObjectsV2CommandOutput,
+  PutObjectCommandInput,
+  PutObjectCommandOutput,
+} from "@aws-sdk/client-s3";
 import type { Interpreter, TypedNode } from "@mvfm/core";
-import { eval_ } from "@mvfm/core";
+import { eval_, typedInterpreter } from "@mvfm/core";
 
 /**
  * S3 client interface consumed by the s3 handler.
@@ -12,18 +24,51 @@ export interface S3Client {
   execute(command: string, input: Record<string, unknown>): Promise<unknown>;
 }
 
-/** Map from AST node kind to S3 command name. */
-const COMMAND_MAP: Record<string, string> = {
-  "s3/put_object": "PutObject",
-  "s3/get_object": "GetObject",
-  "s3/delete_object": "DeleteObject",
-  "s3/head_object": "HeadObject",
-  "s3/list_objects_v2": "ListObjectsV2",
-};
+/** A `s3/put_object` node for PutObject execution. */
+export interface S3PutObjectNode extends TypedNode<PutObjectCommandOutput> {
+  kind: "s3/put_object";
+  input: TypedNode<PutObjectCommandInput>;
+}
 
-interface S3Node extends TypedNode<unknown> {
-  kind: string;
-  input: TypedNode<Record<string, unknown>>;
+/** A `s3/get_object` node for GetObject execution. */
+export interface S3GetObjectNode extends TypedNode<GetObjectCommandOutput> {
+  kind: "s3/get_object";
+  input: TypedNode<GetObjectCommandInput>;
+}
+
+/** A `s3/delete_object` node for DeleteObject execution. */
+export interface S3DeleteObjectNode extends TypedNode<DeleteObjectCommandOutput> {
+  kind: "s3/delete_object";
+  input: TypedNode<DeleteObjectCommandInput>;
+}
+
+/** A `s3/head_object` node for HeadObject execution. */
+export interface S3HeadObjectNode extends TypedNode<HeadObjectCommandOutput> {
+  kind: "s3/head_object";
+  input: TypedNode<HeadObjectCommandInput>;
+}
+
+/** A `s3/list_objects_v2` node for ListObjectsV2 execution. */
+export interface S3ListObjectsV2Node extends TypedNode<ListObjectsV2CommandOutput> {
+  kind: "s3/list_objects_v2";
+  input: TypedNode<ListObjectsV2CommandInput>;
+}
+
+type S3Kind =
+  | "s3/put_object"
+  | "s3/get_object"
+  | "s3/delete_object"
+  | "s3/head_object"
+  | "s3/list_objects_v2";
+
+declare module "@mvfm/core" {
+  interface NodeTypeMap {
+    "s3/put_object": S3PutObjectNode;
+    "s3/get_object": S3GetObjectNode;
+    "s3/delete_object": S3DeleteObjectNode;
+    "s3/head_object": S3HeadObjectNode;
+    "s3/list_objects_v2": S3ListObjectsV2Node;
+  }
 }
 
 /**
@@ -33,12 +78,41 @@ interface S3Node extends TypedNode<unknown> {
  * @returns An Interpreter handling all s3 node kinds.
  */
 export function createS3Interpreter(client: S3Client): Interpreter {
-  const handler = async function* (node: S3Node) {
-    const command = COMMAND_MAP[node.kind];
-    if (!command) throw new Error(`S3 interpreter: unknown node kind "${node.kind}"`);
-    const input = yield* eval_(node.input);
-    return await client.execute(command, input);
-  };
-
-  return Object.fromEntries(Object.keys(COMMAND_MAP).map((kind) => [kind, handler]));
+  return typedInterpreter<S3Kind>()({
+    "s3/put_object": async function* (node: S3PutObjectNode) {
+      const input = yield* eval_(node.input);
+      return (await client.execute(
+        "PutObject",
+        input as unknown as Record<string, unknown>,
+      )) as PutObjectCommandOutput;
+    },
+    "s3/get_object": async function* (node: S3GetObjectNode) {
+      const input = yield* eval_(node.input);
+      return (await client.execute(
+        "GetObject",
+        input as unknown as Record<string, unknown>,
+      )) as GetObjectCommandOutput;
+    },
+    "s3/delete_object": async function* (node: S3DeleteObjectNode) {
+      const input = yield* eval_(node.input);
+      return (await client.execute(
+        "DeleteObject",
+        input as unknown as Record<string, unknown>,
+      )) as DeleteObjectCommandOutput;
+    },
+    "s3/head_object": async function* (node: S3HeadObjectNode) {
+      const input = yield* eval_(node.input);
+      return (await client.execute(
+        "HeadObject",
+        input as unknown as Record<string, unknown>,
+      )) as HeadObjectCommandOutput;
+    },
+    "s3/list_objects_v2": async function* (node: S3ListObjectsV2Node) {
+      const input = yield* eval_(node.input);
+      return (await client.execute(
+        "ListObjectsV2",
+        input as unknown as Record<string, unknown>,
+      )) as ListObjectsV2CommandOutput;
+    },
+  });
 }

--- a/packages/plugin-s3/src/__tests__/node-type-map.type-test.ts
+++ b/packages/plugin-s3/src/__tests__/node-type-map.type-test.ts
@@ -1,0 +1,34 @@
+import type { TypedNode } from "@mvfm/core";
+import { typedInterpreter } from "@mvfm/core";
+import type { S3GetObjectNode, S3PutObjectNode } from "../3.989.0/interpreter";
+
+const _s3Positive = typedInterpreter<"s3/put_object" | "s3/get_object">()({
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "s3/put_object": async function* (_node: S3PutObjectNode) {
+    return { $metadata: {} };
+  },
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "s3/get_object": async function* (_node: S3GetObjectNode) {
+    return { $metadata: {} };
+  },
+});
+
+const _s3BadAny = typedInterpreter<"s3/put_object">()({
+  // @ts-expect-error registered kind cannot use any node parameter
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "s3/put_object": async function* (_node: any) {
+    return {};
+  },
+});
+
+interface WrongS3Node extends TypedNode<number> {
+  kind: "s3/get_object";
+}
+
+const _s3BadNode = typedInterpreter<"s3/get_object">()({
+  // @ts-expect-error wrong node shape for s3/get_object
+  // biome-ignore lint/correctness/useYield: compile-time signature test
+  "s3/get_object": async function* (_node: WrongS3Node) {
+    return 1;
+  },
+});


### PR DESCRIPTION
Closes #213

## What this does
This adds explicit typed node interfaces for all `fetch/*`, `s3/*`, and `cloudflare-kv/*` interpreter node kinds listed in #213. Each plugin interpreter now uses `typedInterpreter` and registers its node kinds via `declare module "@mvfm/core"` `NodeTypeMap` augmentation, matching the #197 pattern used by core/redis/postgres. It also adds compile-time type-test files in each plugin to verify correct handler typing and expected type errors for invalid handler signatures.

## Design alignment
- #213 does not explicitly cite specific VISION.md principles; this implementation aligns with deterministic, inspectable AST execution by tightening compile-time handler contracts without changing runtime behavior.
- Plugin boundaries remain intact: all node kinds stay namespaced (`fetch/*`, `s3/*`, `cloudflare-kv/*`) and interpreter ownership remains within each plugin.
- The implementation follows the plugin contract and typed interpreter direction established by #197.

## Validation performed
- `pnpm build` (worktree `.worktrees/issue-213`): PASS.
- `pnpm check` (worktree `.worktrees/issue-213`): PASS.
- `pnpm test` (workspace): FAIL due environment constraints unrelated to this change:
  - `@mvfm/plugin-postgres` requires a container runtime (`Could not find a working container runtime strategy`).
  - `@mvfm/plugin-fetch` integration suite cannot bind local port in this sandbox (`listen EPERM: operation not permitted 127.0.0.1`).
- Targeted suites for changed plugins:
  - `pnpm --filter @mvfm/plugin-cloudflare-kv run test`: PASS.
  - `pnpm --filter @mvfm/plugin-s3 run test`: unit/index tests PASS; integration suite skipped/fails without container runtime.
  - `pnpm --filter @mvfm/plugin-fetch run test`: unit/interpreter tests PASS; integration suite fails with sandbox port-bind restriction.
