### PR TITLE
feat(zod): add template literal and stringbool interpreters

### DIFF
--- a/packages/docs/src/examples/zod-schemas-more.ts
+++ b/packages/docs/src/examples/zod-schemas-more.ts
@@ -62,6 +62,18 @@ await foldAST(
 );`,
     plugins: ZP,
   },
+  "zod/stringbool": {
+    description: "Schema that coerces string values to booleans",
+    code: `const app = mvfm(prelude, zod);
+const prog = app({ value: "string" }, ($) => {
+  return $.zod.stringbool().parse($.input.value);
+});
+await foldAST(
+  defaults(app),
+  injectInput(prog, { value: "true" })
+);`,
+    plugins: ZP,
+  },
   "zod/symbol": {
     description: "Schema that validates symbol values",
     code: `const app = mvfm(prelude, zod);
@@ -71,6 +83,18 @@ const prog = app({ value: "string" }, ($) => {
 await foldAST(
   defaults(app),
   injectInput(prog, { value: Symbol("test") })
+);`,
+    plugins: ZP,
+  },
+  "zod/template_literal": {
+    description: "Schema for validating strings matching a template literal pattern",
+    code: `const app = mvfm(prelude, zod);
+const prog = app({ value: "string" }, ($) => {
+  return $.zod.templateLiteral([$.zod.number(), "px"]).parse($.input.value);
+});
+await foldAST(
+  defaults(app),
+  injectInput(prog, { value: "42px" })
 );`,
     plugins: ZP,
   },

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -34,6 +34,10 @@ import type { ZodStringNamespace } from "./string";
 import { stringNamespace, stringNodeKinds } from "./string";
 import type { ZodStringFormatsNamespace } from "./string-formats";
 import { stringFormatsNamespace, stringFormatsNodeKinds } from "./string-formats";
+import type { ZodStringboolNamespace } from "./stringbool";
+import { stringboolNamespace, stringboolNodeKinds } from "./stringbool";
+import type { ZodTemplateLiteralNamespace } from "./template-literal";
+import { templateLiteralNamespace, templateLiteralNodeKinds } from "./template-literal";
 import type { ZodTransformNamespace } from "./transform";
 import { transformNamespace, transformNodeKinds } from "./transform";
 import type { ZodTupleNamespace } from "./tuple";
@@ -63,6 +67,8 @@ export { ZodSimpleBuilder } from "./special";
 export { ZodStringBuilder } from "./string";
 export type { ZodIsoNamespace, ZodStringFormatsNamespace } from "./string-formats";
 export { buildStringFormat } from "./string-formats";
+export { ZodStringboolBuilder } from "./stringbool";
+export { ZodTemplateLiteralBuilder } from "./template-literal";
 export { ZodTransformBuilder } from "./transform";
 export { ZodTupleBuilder } from "./tuple";
 export type {
@@ -106,7 +112,9 @@ export interface ZodNamespace
     ZodPrimitivesNamespace,
     ZodRecordNamespace,
     ZodSpecialNamespace,
+    ZodStringboolNamespace,
     ZodStringFormatsNamespace,
+    ZodTemplateLiteralNamespace,
     ZodTransformNamespace,
     ZodTupleNamespace,
     ZodUnionNamespace {
@@ -164,7 +172,9 @@ export const zod = definePlugin({
     ...coerceNodeKinds,
     ...recordNodeKinds,
     ...specialNodeKinds,
+    ...stringboolNodeKinds,
     ...stringFormatsNodeKinds,
+    ...templateLiteralNodeKinds,
     ...transformNodeKinds,
     ...tupleNodeKinds,
     ...unionNodeKinds,
@@ -190,7 +200,9 @@ export const zod = definePlugin({
         ...coerceNamespace(ctx, parseError),
         ...recordNamespace(ctx, parseError),
         ...specialNamespace(ctx, parseError),
+        ...stringboolNamespace(ctx),
         ...stringFormatsNamespace(ctx, parseError),
+        ...templateLiteralNamespace(ctx),
         ...transformNamespace(ctx),
         ...tupleNamespace(ctx, parseError),
         ...unionNamespace(ctx, parseError),

--- a/packages/plugin-zod/src/interpreter.ts
+++ b/packages/plugin-zod/src/interpreter.ts
@@ -26,6 +26,8 @@ import { primitivesInterpreter } from "./primitives";
 import { createRecordInterpreter } from "./record";
 import { specialInterpreter } from "./special";
 import { stringInterpreter } from "./string";
+import { stringboolInterpreter } from "./stringbool";
+import { createTemplateLiteralInterpreter } from "./template-literal";
 import type { AnyZodSchemaNode, ValidationASTNode } from "./types";
 import { createUnionInterpreter } from "./union";
 import { zodNonoptional, zodPrefault, zodTupleRest } from "./zod-compat";
@@ -39,6 +41,7 @@ const leafHandlers: SchemaInterpreterMap = {
   ...numberInterpreter,
   ...primitivesInterpreter,
   ...specialInterpreter,
+  ...stringboolInterpreter,
 };
 
 function createSchemaBuilder() {
@@ -124,6 +127,7 @@ function createSchemaBuilder() {
         ...createRecordInterpreter(buildSchema),
         ...createMapSetInterpreter(buildSchema),
         ...createLazyInterpreter(buildSchema),
+        ...createTemplateLiteralInterpreter(buildSchema),
       };
     }
     return schemaHandlers;

--- a/packages/plugin-zod/src/stringbool.ts
+++ b/packages/plugin-zod/src/stringbool.ts
@@ -1,0 +1,110 @@
+import type { PluginContext, TypedNode } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  ZodSchemaNodeBase,
+} from "./types";
+
+interface ZodStringboolNode extends ZodSchemaNodeBase {
+  kind: "zod/stringbool";
+  truthy?: string[];
+  falsy?: string[];
+  coerce?: boolean;
+}
+
+/**
+ * Builder for Zod stringbool schemas.
+ *
+ * Stringbool schemas coerce string values to booleans.
+ * By default, "true"/"1"/"yes"/"on"/"y"/"enabled" map to `true`
+ * and "false"/"0"/"no"/"off"/"n"/"disabled" map to `false`.
+ * Custom truthy/falsy sets and case sensitivity can be configured.
+ *
+ * @typeParam T - The output type (boolean)
+ */
+export class ZodStringboolBuilder extends ZodSchemaBuilder<boolean> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/stringbool", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | TypedNode;
+    extra?: Record<string, unknown>;
+  }): ZodStringboolBuilder {
+    return new ZodStringboolBuilder(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Node kinds contributed by the stringbool schema. */
+export const stringboolNodeKinds: string[] = ["zod/stringbool"];
+
+/** Options for stringbool schema construction. */
+export interface StringboolOptions {
+  /** Custom truthy string values. */
+  truthy?: string[];
+  /** Custom falsy string values. */
+  falsy?: string[];
+  /** Whether matching is case-sensitive (default: coerces case). */
+  coerce?: boolean;
+}
+
+/**
+ * Namespace fragment for stringbool schema factories.
+ */
+export interface ZodStringboolNamespace {
+  /**
+   * Create a stringbool schema that coerces strings to booleans.
+   *
+   * @example
+   * ```ts
+   * $.zod.stringbool()               // "true"→true, "false"→false
+   * $.zod.stringbool({ truthy: ["yep"], falsy: ["nope"] })
+   * ```
+   */
+  stringbool(opts?: StringboolOptions): ZodStringboolBuilder;
+}
+
+/** Build the stringbool namespace factory methods. */
+export function stringboolNamespace(ctx: PluginContext): ZodStringboolNamespace {
+  return {
+    stringbool(opts?: StringboolOptions): ZodStringboolBuilder {
+      const extra: Record<string, unknown> = {};
+      if (opts?.truthy) extra.truthy = opts.truthy;
+      if (opts?.falsy) extra.falsy = opts.falsy;
+      if (opts?.coerce !== undefined) extra.coerce = opts.coerce;
+      return new ZodStringboolBuilder(ctx, [], [], undefined, extra);
+    },
+  };
+}
+
+/** Interpreter handlers for stringbool schema nodes. */
+export const stringboolInterpreter: SchemaInterpreterMap = {
+  // biome-ignore lint/correctness/useYield: conforms to SchemaInterpreterMap generator signature
+  "zod/stringbool": async function* (
+    node: ZodStringboolNode,
+  ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+    const opts: Record<string, unknown> = {};
+    if (node.truthy) opts.truthy = node.truthy;
+    if (node.falsy) opts.falsy = node.falsy;
+    if (node.coerce !== undefined) opts.coerce = node.coerce;
+    return Object.keys(opts).length > 0 ? z.stringbool(opts) : z.stringbool();
+  },
+};

--- a/packages/plugin-zod/src/template-literal.ts
+++ b/packages/plugin-zod/src/template-literal.ts
@@ -1,0 +1,116 @@
+import type { PluginContext, TypedNode } from "@mvfm/core";
+import { z } from "zod";
+import { ZodSchemaBuilder } from "./base";
+import type { SchemaInterpreterMap } from "./interpreter-utils";
+import type {
+  CheckDescriptor,
+  ErrorConfig,
+  RefinementDescriptor,
+  SchemaASTNode,
+  WrapperASTNode,
+  ZodSchemaNodeBase,
+} from "./types";
+
+type TemplatePart = string | SchemaASTNode | WrapperASTNode;
+
+interface ZodTemplateLiteralNode extends ZodSchemaNodeBase {
+  kind: "zod/template_literal";
+  parts: TemplatePart[];
+}
+
+/**
+ * Builder for Zod template literal schemas.
+ *
+ * Template literals validate strings matching a pattern of static
+ * and dynamic parts. Dynamic parts are other Zod schemas (string,
+ * number, etc.) that match their respective types within the template.
+ *
+ * @typeParam T - The output type this schema validates to
+ */
+export class ZodTemplateLiteralBuilder<T extends string> extends ZodSchemaBuilder<T> {
+  constructor(
+    ctx: PluginContext,
+    checks: readonly CheckDescriptor[] = [],
+    refinements: readonly RefinementDescriptor[] = [],
+    error?: ErrorConfig,
+    extra: Record<string, unknown> = {},
+  ) {
+    super(ctx, "zod/template_literal", checks, refinements, error, extra);
+  }
+
+  protected _clone(overrides?: {
+    checks?: readonly CheckDescriptor[];
+    refinements?: readonly RefinementDescriptor[];
+    error?: string | TypedNode;
+    extra?: Record<string, unknown>;
+  }): ZodTemplateLiteralBuilder<T> {
+    return new ZodTemplateLiteralBuilder<T>(
+      this._ctx,
+      overrides?.checks ?? this._checks,
+      overrides?.refinements ?? this._refinements,
+      overrides?.error ?? this._error,
+      overrides?.extra ?? { ...this._extra },
+    );
+  }
+}
+
+/** Node kinds contributed by the template literal schema. */
+export const templateLiteralNodeKinds: string[] = ["zod/template_literal"];
+
+/**
+ * Namespace fragment for template literal schema factories.
+ */
+export interface ZodTemplateLiteralNamespace {
+  /**
+   * Create a template literal schema.
+   *
+   * @example
+   * ```ts
+   * $.zod.templateLiteral(["hello, ", $.zod.string(), "!"])
+   * // matches: "hello, world!"
+   *
+   * $.zod.templateLiteral([$.zod.number(), "px"])
+   * // matches: "42px", "3.14px"
+   * ```
+   */
+  templateLiteral<T extends string>(
+    parts: (string | ZodSchemaBuilder<unknown>)[],
+  ): ZodTemplateLiteralBuilder<T>;
+}
+
+/** Build the template literal namespace factory methods. */
+export function templateLiteralNamespace(ctx: PluginContext): ZodTemplateLiteralNamespace {
+  return {
+    templateLiteral<T extends string>(
+      parts: (string | ZodSchemaBuilder<unknown>)[],
+    ): ZodTemplateLiteralBuilder<T> {
+      const astParts: TemplatePart[] = parts.map((p) =>
+        typeof p === "string" ? p : p.__schemaNode,
+      );
+      return new ZodTemplateLiteralBuilder<T>(ctx, [], [], undefined, { parts: astParts });
+    },
+  };
+}
+
+/** Create interpreter handlers for template literal schema nodes. */
+export function createTemplateLiteralInterpreter(
+  buildSchema: (node: ZodSchemaNodeBase) => AsyncGenerator<TypedNode, z.ZodType, unknown>,
+): SchemaInterpreterMap {
+  return {
+    "zod/template_literal": async function* (
+      node: ZodTemplateLiteralNode,
+    ): AsyncGenerator<TypedNode, z.ZodType, unknown> {
+      const builtParts: (string | z.ZodType)[] = [];
+      for (const part of node.parts) {
+        if (typeof part === "string") {
+          builtParts.push(part);
+        } else {
+          builtParts.push(yield* buildSchema(part as ZodSchemaNodeBase));
+        }
+      }
+      // Cast needed: Zod's internal $ZodTemplateLiteralPart requires
+      // schemas with a `pattern` property, but at runtime any ZodType works.
+      return z.templateLiteral(builtParts as Parameters<typeof z.templateLiteral>[0]);
+    },
+  };
+}

--- a/packages/plugin-zod/tests/stringbool-interpreter.test.ts
+++ b/packages/plugin-zod/tests/stringbool-interpreter.test.ts
@@ -1,0 +1,76 @@
+import {
+  coreInterpreter,
+  foldAST,
+  injectInput,
+  mvfm,
+  type Program,
+  strInterpreter,
+} from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { createZodInterpreter, zod } from "../src/index";
+
+async function run(prog: Program, input: Record<string, unknown> = {}) {
+  const interp = { ...coreInterpreter, ...strInterpreter, ...createZodInterpreter() };
+  return await foldAST(interp, injectInput(prog, input));
+}
+
+const app = mvfm(zod);
+
+describe("zodInterpreter: stringbool schemas (#156)", () => {
+  it("parse() coerces 'true' to true", async () => {
+    const prog = app(($) => $.zod.stringbool().parse($.input.value));
+    expect(await run(prog, { value: "true" })).toBe(true);
+  });
+
+  it("parse() coerces 'false' to false", async () => {
+    const prog = app(($) => $.zod.stringbool().parse($.input.value));
+    expect(await run(prog, { value: "false" })).toBe(false);
+  });
+
+  it("parse() coerces '1' to true and '0' to false", async () => {
+    const prog = app(($) => $.zod.stringbool().parse($.input.value));
+    expect(await run(prog, { value: "1" })).toBe(true);
+    expect(await run(prog, { value: "0" })).toBe(false);
+  });
+
+  it("parse() coerces 'yes'/'no' to true/false", async () => {
+    const prog = app(($) => $.zod.stringbool().parse($.input.value));
+    expect(await run(prog, { value: "yes" })).toBe(true);
+    expect(await run(prog, { value: "no" })).toBe(false);
+  });
+
+  it("parse() rejects non-boolean strings", async () => {
+    const prog = app(($) => $.zod.stringbool().parse($.input.value));
+    await expect(run(prog, { value: "maybe" })).rejects.toThrow();
+  });
+
+  it("custom truthy/falsy values", async () => {
+    const prog = app(($) =>
+      $.zod.stringbool({ truthy: ["yep"], falsy: ["nah"] }).parse($.input.value),
+    );
+    expect(await run(prog, { value: "yep" })).toBe(true);
+    expect(await run(prog, { value: "nah" })).toBe(false);
+  });
+
+  it("safeParse() returns success for valid input", async () => {
+    const prog = app(($) => $.zod.stringbool().safeParse($.input.value));
+    const result = (await run(prog, { value: "true" })) as any;
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(true);
+  });
+
+  it("safeParse() returns failure for invalid input", async () => {
+    const prog = app(($) => $.zod.stringbool().safeParse($.input.value));
+    const result = (await run(prog, { value: "banana" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("stringbool with optional wrapper", async () => {
+    const prog = app(($) => $.zod.stringbool().optional().safeParse($.input.value));
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "true" })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+    expect(valid.data).toBe(true);
+  });
+});

--- a/packages/plugin-zod/tests/stringbool.test.ts
+++ b/packages/plugin-zod/tests/stringbool.test.ts
@@ -1,0 +1,50 @@
+import { mvfm } from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { ZodStringboolBuilder, zod } from "../src/index";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+describe("stringbool schemas (#156)", () => {
+  it("$.zod.stringbool() returns a ZodStringboolBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.stringbool();
+      expect(builder).toBeInstanceOf(ZodStringboolBuilder);
+      return builder.parse(42);
+    });
+  });
+
+  it("produces correct AST with defaults", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.stringbool().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/stringbool");
+  });
+
+  it("produces correct AST with custom truthy/falsy", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.stringbool({ truthy: ["yep"], falsy: ["nah"] }).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/stringbool");
+    expect(ast.result.schema.truthy).toEqual(["yep"]);
+    expect(ast.result.schema.falsy).toEqual(["nah"]);
+  });
+
+  it("produces correct AST with coerce option", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.stringbool({ coerce: false }).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/stringbool");
+    expect(ast.result.schema.coerce).toBe(false);
+  });
+
+  it("inherits wrapper methods", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.stringbool().optional().parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/stringbool");
+  });
+});

--- a/packages/plugin-zod/tests/template-literal-interpreter.test.ts
+++ b/packages/plugin-zod/tests/template-literal-interpreter.test.ts
@@ -1,0 +1,74 @@
+import {
+  coreInterpreter,
+  foldAST,
+  injectInput,
+  mvfm,
+  type Program,
+  strInterpreter,
+} from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { createZodInterpreter, zod } from "../src/index";
+
+async function run(prog: Program, input: Record<string, unknown> = {}) {
+  const interp = { ...coreInterpreter, ...strInterpreter, ...createZodInterpreter() };
+  return await foldAST(interp, injectInput(prog, input));
+}
+
+const app = mvfm(zod);
+
+describe("zodInterpreter: template literal schemas (#156)", () => {
+  it("parse() accepts matching template literal", async () => {
+    const prog = app(($) =>
+      $.zod.templateLiteral(["hello, ", $.zod.string(), "!"]).parse($.input.value),
+    );
+    expect(await run(prog, { value: "hello, world!" })).toBe("hello, world!");
+  });
+
+  it("parse() rejects non-matching template literal", async () => {
+    const prog = app(($) =>
+      $.zod.templateLiteral(["hello, ", $.zod.string(), "!"]).parse($.input.value),
+    );
+    await expect(run(prog, { value: "goodbye" })).rejects.toThrow();
+  });
+
+  it("template literal with number schema", async () => {
+    const prog = app(($) => $.zod.templateLiteral([$.zod.number(), "px"]).parse($.input.value));
+    expect(await run(prog, { value: "42px" })).toBe("42px");
+  });
+
+  it("template literal with number rejects invalid", async () => {
+    const prog = app(($) => $.zod.templateLiteral([$.zod.number(), "px"]).parse($.input.value));
+    await expect(run(prog, { value: "abcpx" })).rejects.toThrow();
+  });
+
+  it("safeParse() returns success for match", async () => {
+    const prog = app(($) => $.zod.templateLiteral(["v", $.zod.number()]).safeParse($.input.value));
+    const result = (await run(prog, { value: "v42" })) as any;
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("v42");
+  });
+
+  it("safeParse() returns failure for non-match", async () => {
+    const prog = app(($) => $.zod.templateLiteral(["v", $.zod.number()]).safeParse($.input.value));
+    const result = (await run(prog, { value: "xyz" })) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it("template literal with enum-like parts", async () => {
+    const prog = app(($) =>
+      $.zod.templateLiteral([$.zod.number(), $.zod.enum(["px", "em", "rem"])]).parse($.input.value),
+    );
+    expect(await run(prog, { value: "16px" })).toBe("16px");
+    expect(await run(prog, { value: "1.5em" })).toBe("1.5em");
+  });
+
+  it("template literal with optional wrapper", async () => {
+    const prog = app(($) =>
+      $.zod.templateLiteral(["test", $.zod.number()]).optional().safeParse($.input.value),
+    );
+    const undef = (await run(prog, { value: undefined })) as any;
+    const valid = (await run(prog, { value: "test42" })) as any;
+    expect(undef.success).toBe(true);
+    expect(valid.success).toBe(true);
+  });
+});

--- a/packages/plugin-zod/tests/template-literal.test.ts
+++ b/packages/plugin-zod/tests/template-literal.test.ts
@@ -1,0 +1,49 @@
+import { mvfm } from "@mvfm/core";
+import { describe, expect, it } from "vitest";
+import { ZodTemplateLiteralBuilder, zod } from "../src/index";
+
+function strip(ast: unknown): unknown {
+  return JSON.parse(JSON.stringify(ast, (k, v) => (k === "__id" ? undefined : v)));
+}
+
+describe("template literal schemas (#156)", () => {
+  it("$.zod.templateLiteral() returns a ZodTemplateLiteralBuilder", () => {
+    const app = mvfm(zod);
+    app(($) => {
+      const builder = $.zod.templateLiteral(["hello ", $.zod.string()]);
+      expect(builder).toBeInstanceOf(ZodTemplateLiteralBuilder);
+      return builder.parse(42);
+    });
+  });
+
+  it("produces correct AST with string and schema parts", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.templateLiteral(["hello, ", $.zod.string(), "!"]).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/template_literal");
+    expect(ast.result.schema.parts).toHaveLength(3);
+    expect(ast.result.schema.parts[0]).toBe("hello, ");
+    expect(ast.result.schema.parts[1].kind).toBe("zod/string");
+    expect(ast.result.schema.parts[2]).toBe("!");
+  });
+
+  it("produces correct AST with number schema", () => {
+    const app = mvfm(zod);
+    const prog = app(($) => $.zod.templateLiteral([$.zod.number(), "px"]).parse($.input));
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/template_literal");
+    expect(ast.result.schema.parts).toHaveLength(2);
+    expect(ast.result.schema.parts[0].kind).toBe("zod/number");
+    expect(ast.result.schema.parts[1]).toBe("px");
+  });
+
+  it("inherits wrapper methods", () => {
+    const app = mvfm(zod);
+    const prog = app(($) =>
+      $.zod.templateLiteral(["test", $.zod.string()]).optional().parse($.input),
+    );
+    const ast = strip(prog.ast) as any;
+    expect(ast.result.schema.kind).toBe("zod/optional");
+    expect(ast.result.schema.inner.kind).toBe("zod/template_literal");
+  });
+});


### PR DESCRIPTION
Closes #156
Closes #119

## What this does

Adds interpreter support for `zod/template_literal` and `zod/stringbool` node kinds. Template literals validate strings matching patterns of static and dynamic parts (e.g. `"42px"`). Stringbool coerces string values like `"true"/"1"/"yes"` to booleans.

## Design alignment

Follows the established per-type module pattern: each new type gets a builder class extending `ZodSchemaBuilder`, a namespace factory, node kinds array, and interpreter handler. Template literal uses the factory pattern (`createTemplateLiteralInterpreter(buildSchema)`) since it needs recursive schema building for dynamic parts. Stringbool is a leaf handler (no nested schemas).

## Validation performed

- `pnpm --filter @mvfm/plugin-zod run build` — passes
- `pnpm --filter @mvfm/plugin-zod run check` — biome + tsc pass
- `pnpm --filter @mvfm/plugin-zod run test -- --run` — 488 tests pass (53 files), including 4 new test files (26 new tests: builder AST shape + interpreter round-trip for both types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)