### PR TITLE
test(anthropic): fixture-based integration tests (#75)

### DIFF
--- a/packages/plugin-anthropic/tests/0.74.0/integration.test.ts
+++ b/packages/plugin-anthropic/tests/0.74.0/integration.test.ts
@@ -97,6 +97,9 @@ describe("anthropic integration: batches", () => {
     expect(result.processing_status).toBe("in_progress");
   });
 
+  // ID-based operations: the fixture client matches by operation name only,
+  // not by the actual ID in the path. Contract drift is caught for param-based
+  // operations; for ID-based ones we verify the response shape is correct.
   it("retrieve_message_batch", async () => {
     const prog = app(($) => $.anthropic.messages.batches.retrieve("msgbatch_any"));
     const result = (await run(prog)) as any;

--- a/packages/plugin-anthropic/tests/0.74.0/record-fixtures.ts
+++ b/packages/plugin-anthropic/tests/0.74.0/record-fixtures.ts
@@ -14,6 +14,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import Anthropic from "@anthropic-ai/sdk";
 import { wrapAnthropicSdk } from "../../src/0.74.0/client-anthropic-sdk";
+import type { Fixture } from "./fixture-client";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,11 +43,6 @@ function loadApiKey(): string {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-interface Fixture {
-  request: { method: string; path: string; params?: unknown };
-  response: unknown;
-}
 
 function save(name: string, fixture: Fixture): void {
   const filePath = resolve(FIXTURES_DIR, `${name}.json`);


### PR DESCRIPTION
## Summary
- Add fixture replay client (`fixture-client.ts`) that loads recorded API responses and detects contract drift when request params change
- Add recording script (`record-fixtures.ts`) to capture real Anthropic API responses as committed JSON fixtures
- Add 11 integration tests covering all 9 anthropic operations plus error/fiber composition
- Deduplicate `Fixture` type between record script and replay client

Closes #75

## Test Plan
- [x] All 42 tests pass (`npm test` in plugin-anthropic)
- [x] Build succeeds (`npm run build`)
- [x] Lint/check passes (`npm run check`)
- [x] All files under 300 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)