### PR TITLE
feat(docs): add cloudflare-kv plugin examples

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,6 +14,7 @@
     "@electric-sql/pglite": "^0.3.15",
     "@mvfm/core": "workspace:*",
     "@mvfm/plugin-anthropic": "workspace:*",
+    "@mvfm/plugin-cloudflare-kv": "workspace:*",
     "@mvfm/plugin-console": "workspace:*",
     "@mvfm/plugin-fetch": "workspace:*",
     "@mvfm/plugin-openai": "workspace:*",

--- a/packages/docs/src/components/Playground.tsx
+++ b/packages/docs/src/components/Playground.tsx
@@ -12,6 +12,7 @@ interface PlaygroundProps {
   mockInterpreter?: string;
   redis?: true;
   s3?: true;
+  cloudflareKv?: true;
 }
 
 type DbState = "idle" | "loading" | "ready" | "error";
@@ -28,7 +29,7 @@ function getHighlighter() {
   return highlighterPromise;
 }
 
-export default function Playground({ code: initialCode, pglite, mockInterpreter, redis, s3 }: PlaygroundProps) {
+export default function Playground({ code: initialCode, pglite, mockInterpreter, redis, s3, cloudflareKv }: PlaygroundProps) {
   const [code, setCode] = useState(initialCode);
   const [output, setOutput] = useState<string>("");
   const [isError, setIsError] = useState(false);
@@ -113,6 +114,7 @@ export default function Playground({ code: initialCode, pglite, mockInterpreter,
         pglite ? dbRef.current : undefined,
         redis,
         s3,
+        cloudflareKv,
       );
       const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
       const fn = new AsyncFunction(...scope.paramNames, code);
@@ -141,7 +143,7 @@ export default function Playground({ code: initialCode, pglite, mockInterpreter,
       const prefix = line != null ? `Line ${line}: ` : "";
       setOutput(prefix + err.message);
     }
-  }, [code, pglite, dbState, redis, s3]);
+  }, [code, pglite, dbState, redis, s3, cloudflareKv]);
 
   if (dbState === "loading") {
     return (

--- a/packages/docs/src/examples/cloudflare-kv.ts
+++ b/packages/docs/src/examples/cloudflare-kv.ts
@@ -1,0 +1,95 @@
+import type { NodeExample } from "./types";
+
+const CF_KV = ["@mvfm/plugin-cloudflare-kv"];
+
+const examples: Record<string, NodeExample> = {
+  "cloudflare-kv/get": {
+    description: "Get a text value by key, returning null if missing",
+    code: `const app = mvfm(prelude, cloudflareKv({ namespaceId: "MY_KV" }));
+const prog = app({}, ($) => {
+  return $.begin(
+    $.kv.put("greeting", "hello"),
+    $.kv.get("greeting")
+  );
+});
+await foldAST(
+  defaults(app, { "cloudflare-kv": memoryCloudflareKvInterpreter }),
+  prog
+);`,
+    plugins: CF_KV,
+    cloudflareKv: true,
+  },
+
+  "cloudflare-kv/get_json": {
+    description: "Get a JSON-parsed value by key, returning null if missing",
+    code: `const app = mvfm(prelude, cloudflareKv({ namespaceId: "MY_KV" }));
+const prog = app({}, ($) => {
+  return $.begin(
+    $.kv.put("user", JSON.stringify({ name: "Alice", age: 30 })),
+    $.kv.get("user", "json")
+  );
+});
+await foldAST(
+  defaults(app, { "cloudflare-kv": memoryCloudflareKvInterpreter }),
+  prog
+);`,
+    plugins: CF_KV,
+    cloudflareKv: true,
+  },
+
+  "cloudflare-kv/put": {
+    description: "Store a string value at a key with optional expiration",
+    code: `const app = mvfm(prelude, cloudflareKv({ namespaceId: "MY_KV" }));
+const prog = app({}, ($) => {
+  return $.begin(
+    $.kv.put("session", "abc123", { expirationTtl: 3600 }),
+    $.kv.get("session")
+  );
+});
+await foldAST(
+  defaults(app, { "cloudflare-kv": memoryCloudflareKvInterpreter }),
+  prog
+);`,
+    plugins: CF_KV,
+    cloudflareKv: true,
+  },
+
+  "cloudflare-kv/delete": {
+    description: "Remove a key from the KV namespace",
+    code: `const app = mvfm(prelude, cloudflareKv({ namespaceId: "MY_KV" }));
+const prog = app({}, ($) => {
+  return $.begin(
+    $.kv.put("temp", "data"),
+    $.kv.delete("temp"),
+    $.kv.get("temp")
+  );
+});
+await foldAST(
+  defaults(app, { "cloudflare-kv": memoryCloudflareKvInterpreter }),
+  prog
+);`,
+    plugins: CF_KV,
+    cloudflareKv: true,
+  },
+
+  "cloudflare-kv/list": {
+    description: "List keys with optional prefix filter and pagination",
+    code: `const app = mvfm(prelude, cloudflareKv({ namespaceId: "MY_KV" }));
+const prog = app({}, ($) => {
+  return $.begin(
+    $.kv.put("user:1", "Alice"),
+    $.kv.put("user:2", "Bob"),
+    $.kv.put("config:theme", "dark"),
+    $.kv.list({ prefix: "user:" })
+  );
+});
+await foldAST(
+  defaults(app, { "cloudflare-kv": memoryCloudflareKvInterpreter }),
+  prog
+);`,
+    plugins: CF_KV,
+    cloudflareKv: true,
+  },
+};
+
+export default examples;

--- a/packages/docs/src/examples/index.ts
+++ b/packages/docs/src/examples/index.ts
@@ -1,5 +1,6 @@
 import anthropic from "./anthropic";
 import boolean from "./boolean";
+import cloudflareKv from "./cloudflare-kv";
 import console_ from "./console";
 import control from "./control";
 import core from "./core";
@@ -46,6 +47,7 @@ const modules: Record<string, ExampleEntry>[] = [
   redisLists,
   redisStrings,
   s3,
+  cloudflareKv,
   zodSchemas,
   zodSchemasMore,
   zodWrappers,

--- a/packages/docs/src/examples/types.ts
+++ b/packages/docs/src/examples/types.ts
@@ -13,6 +13,8 @@ export interface NodeExample {
   redis?: true;
   /** When set, the playground provides an in-memory S3 client. */
   s3?: true;
+  /** When set, the playground provides an in-memory Cloudflare KV client. */
+  cloudflareKv?: true;
 }
 
 /** Prose landing page for a plugin namespace (e.g. /core, /postgres). */

--- a/packages/docs/src/memory-cloudflare-kv-client.ts
+++ b/packages/docs/src/memory-cloudflare-kv-client.ts
@@ -1,0 +1,54 @@
+import type { CloudflareKvClient } from "@mvfm/plugin-cloudflare-kv";
+
+/**
+ * In-memory implementation of {@link CloudflareKvClient} for the docs playground.
+ *
+ * Stores data in plain Maps, emulating Cloudflare KV get/put/delete/list
+ * semantics. Not suitable for production use — designed for deterministic
+ * doc examples that run entirely in the browser.
+ */
+export class MemoryCloudflareKvClient implements CloudflareKvClient {
+  private store = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+
+  async getJson<T = unknown>(key: string): Promise<T | null> {
+    const raw = this.store.get(key);
+    if (raw == null) return null;
+    return JSON.parse(raw) as T;
+  }
+
+  async put(
+    key: string,
+    value: string,
+    _options?: { expiration?: number; expirationTtl?: number; metadata?: unknown },
+  ): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async list(options?: { limit?: number; prefix?: string; cursor?: string }): Promise<{
+    keys: Array<{ name: string; expiration?: number }>;
+    list_complete: boolean;
+    cursor?: string;
+  }> {
+    let keys = [...this.store.keys()].sort();
+    if (options?.prefix) {
+      keys = keys.filter((k) => k.startsWith(options.prefix!));
+    }
+    const startIdx = options?.cursor ? parseInt(options.cursor, 10) : 0;
+    const limit = options?.limit ?? 1000;
+    const page = keys.slice(startIdx, startIdx + limit);
+    const done = startIdx + limit >= keys.length;
+    return {
+      keys: page.map((name) => ({ name })),
+      list_complete: done,
+      cursor: done ? undefined : String(startIdx + limit),
+    };
+  }
+}

--- a/packages/docs/src/pages/[...slug].astro
+++ b/packages/docs/src/pages/[...slug].astro
@@ -47,7 +47,7 @@ const isIndex = isNamespaceIndex(example);
           <div class="playground-fallback border border-base-800">
             <Code code={example.code} lang="typescript" theme={MONO_THEME} />
           </div>
-          <Playground code={example.code} pglite={example.pglite} mockInterpreter={example.mockInterpreter} redis={example.redis} s3={example.s3} client:load />
+          <Playground code={example.code} pglite={example.pglite} mockInterpreter={example.mockInterpreter} redis={example.redis} s3={example.s3} cloudflareKv={example.cloudflareKv} client:load />
         </div>
       </>
     )}

--- a/packages/docs/src/playground-scope.ts
+++ b/packages/docs/src/playground-scope.ts
@@ -10,6 +10,7 @@ export async function createPlaygroundScope(
   pgliteDb?: unknown,
   redis?: true,
   s3?: true,
+  cloudflareKv?: true,
 ) {
   const core = await import("@mvfm/core");
   const pluginConsole = await import("@mvfm/plugin-console");
@@ -119,6 +120,15 @@ export async function createPlaygroundScope(
     const client = new MemoryRedisClient();
     injected.redis = pluginRedis.redis();
     injected.memoryRedisInterpreter = pluginRedis.createRedisInterpreter(client);
+  }
+
+  // Wire in-memory Cloudflare KV when cloudflareKv flag is set
+  if (cloudflareKv) {
+    const { MemoryCloudflareKvClient } = await import("./memory-cloudflare-kv-client");
+    const pluginCfKv = await import("@mvfm/plugin-cloudflare-kv");
+    const client = new MemoryCloudflareKvClient();
+    injected.cloudflareKv = pluginCfKv.cloudflareKv;
+    injected.memoryCloudflareKvInterpreter = pluginCfKv.createCloudflareKvInterpreter(client);
   }
 
   // Wire in-memory S3 when s3 flag is set

--- a/packages/docs/tests/examples.test.ts
+++ b/packages/docs/tests/examples.test.ts
@@ -56,6 +56,12 @@ describe("docs examples", () => {
         const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
         const fn = new AsyncFunction(...paramNames, example.code);
         await fn(...paramValues);
+      } else if (example.cloudflareKv) {
+        // Cloudflare KV examples: spin up in-memory KV client
+        const { paramNames, paramValues } = await createPlaygroundScope(fakeConsole, undefined, undefined, undefined, undefined, true);
+        const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+        const fn = new AsyncFunction(...paramNames, example.code);
+        await fn(...paramValues);
       } else if (example.s3) {
         // S3 examples: spin up in-memory S3 client
         const { paramNames, paramValues } = await createPlaygroundScope(fakeConsole, undefined, undefined, undefined, true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@mvfm/plugin-anthropic':
         specifier: workspace:*
         version: link:../plugin-anthropic
+      '@mvfm/plugin-cloudflare-kv':
+        specifier: workspace:*
+        version: link:../plugin-cloudflare-kv
       '@mvfm/plugin-console':
         specifier: workspace:*
         version: link:../plugin-console

--- a/scripts/check-docs-coverage.ts
+++ b/scripts/check-docs-coverage.ts
@@ -30,6 +30,7 @@ import { pino as pinoPlugin } from "../packages/plugin-pino/src/10.3.1/index.js"
 import { zod as zodPlugin } from "../packages/plugin-zod/src/index.js";
 import { openai as openaiPlugin } from "../packages/plugin-openai/src/6.21.0/index.js";
 import { anthropic as anthropicPlugin } from "../packages/plugin-anthropic/src/0.74.0/index.js";
+import { cloudflareKv as cloudflareKvPlugin } from "../packages/plugin-cloudflare-kv/src/4.20260213.0/index.js";
 import { getAllExamples } from "../packages/docs/src/examples/index.js";
 
 // Internal node kinds excluded from coverage requirements.
@@ -67,6 +68,7 @@ const plugins: Array<{ nodeKinds: string[]; traits?: any }> = [
   zodPlugin,
   openaiPlugin({ apiKey: "unused" }),
   anthropicPlugin({ apiKey: "unused" }),
+  cloudflareKvPlugin({ namespaceId: "unused" }),
 ];
 
 // Also include core node kinds that aren't from plugins


### PR DESCRIPTION
Closes #251

## What this does

Adds documentation examples for all 5 cloudflare-kv node kinds (`get`, `get_json`, `put`, `delete`, `list`) following the established redis pattern. Includes an in-memory `MemoryCloudflareKvClient` for playground execution.

## Design alignment

- Full execution pipeline (`app → prog → foldAST`) for every example
- Plugin examples follow the same flag-based playground wiring as redis/s3
- Coverage script now includes cloudflare-kv (222 total node kinds documented)

## Validation performed

- `npm run build` — passes (core + cloudflare-kv)
- `npm test` — 42 cloudflare-kv tests pass, 370 core tests pass
- `npx tsx scripts/check-docs-coverage.ts` — all 222 node kinds covered
- All 5 cloudflare-kv node kinds have examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added Cloudflare KV support to the documentation playground with example code demonstrating get, getJson, put, delete, and list operations for key-value workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->