### PR TITLE
refactor: tighten Liftable<T> types on cloudflare-kv and redis

### DIFF
--- a/packages/plugin-cloudflare-kv/src/4.20260213.0/index.ts
+++ b/packages/plugin-cloudflare-kv/src/4.20260213.0/index.ts
@@ -88,8 +88,15 @@ function buildKvApi() {
       key: string | CExpr<string>,
       value: string | CExpr<string>,
       ...args: [] | [Liftable<KvPutOptions>]
-    ): CExpr<void, "cloudflare-kv/put", [string | CExpr<string>, string | CExpr<string>, ...([] | [Liftable<KvPutOptions>])]> {
-      return makeCExpr("cloudflare-kv/put", [key, value, ...args] as unknown as [string, string]) as any;
+    ): CExpr<
+      void,
+      "cloudflare-kv/put",
+      [string | CExpr<string>, string | CExpr<string>, ...([] | [Liftable<KvPutOptions>])]
+    > {
+      return makeCExpr("cloudflare-kv/put", [key, value, ...args] as unknown as [
+        string,
+        string,
+      ]) as any;
     },
 
     /** Delete a key. */
@@ -98,7 +105,9 @@ function buildKvApi() {
     },
 
     /** List keys with optional prefix filter and pagination cursor. */
-    list(...args: [] | [Liftable<KvListOptions>]): CExpr<KvListResult, "cloudflare-kv/list", [] | [Liftable<KvListOptions>]> {
+    list(
+      ...args: [] | [Liftable<KvListOptions>]
+    ): CExpr<KvListResult, "cloudflare-kv/list", [] | [Liftable<KvListOptions>]> {
       return makeCExpr("cloudflare-kv/list", args as unknown as unknown[]) as any;
     },
   };

--- a/packages/plugin-cloudflare-kv/src/4.20260213.0/index.ts
+++ b/packages/plugin-cloudflare-kv/src/4.20260213.0/index.ts
@@ -17,7 +17,7 @@
 // NO defaultInterpreter — requires createCloudflareKvInterpreter(client).
 // ============================================================
 
-import type { CExpr, KindSpec, Plugin } from "@mvfm/core";
+import type { CExpr, KindSpec, Liftable, Plugin } from "@mvfm/core";
 import { makeCExpr } from "@mvfm/core";
 
 // ---- Supporting types -------------------------------------
@@ -84,12 +84,12 @@ function buildKvApi() {
     get: kvGet,
 
     /** Store a string value at key with optional expiration settings. */
-    put<A, B, C extends readonly unknown[]>(
-      key: A,
-      value: B,
-      ...args: C
-    ): CExpr<void, "cloudflare-kv/put", [A, B, ...C]> {
-      return makeCExpr("cloudflare-kv/put", [key, value, ...args]) as any;
+    put(
+      key: string | CExpr<string>,
+      value: string | CExpr<string>,
+      ...args: [] | [Liftable<KvPutOptions>]
+    ): CExpr<void, "cloudflare-kv/put", [string | CExpr<string>, string | CExpr<string>, ...([] | [Liftable<KvPutOptions>])]> {
+      return makeCExpr("cloudflare-kv/put", [key, value, ...args] as unknown as [string, string]) as any;
     },
 
     /** Delete a key. */
@@ -98,7 +98,7 @@ function buildKvApi() {
     },
 
     /** List keys with optional prefix filter and pagination cursor. */
-    list<A extends readonly unknown[]>(...args: A): CExpr<KvListResult, "cloudflare-kv/list", A> {
+    list(...args: [] | [Liftable<KvListOptions>]): CExpr<KvListResult, "cloudflare-kv/list", [] | [Liftable<KvListOptions>]> {
       return makeCExpr("cloudflare-kv/list", args as unknown as unknown[]) as any;
     },
   };

--- a/packages/plugin-redis/src/5.4.1/build-methods.ts
+++ b/packages/plugin-redis/src/5.4.1/build-methods.ts
@@ -51,7 +51,9 @@ export function buildRedisApi() {
       return makeCExpr("redis/mget", [...keys]) as any;
     },
     /** Set multiple key-value pairs. */
-    mset(mapping: Liftable<Record<string, string>>): CExpr<"OK", "redis/mset", [Liftable<Record<string, string>>]> {
+    mset(
+      mapping: Liftable<Record<string, string>>,
+    ): CExpr<"OK", "redis/mset", [Liftable<Record<string, string>>]> {
       return makeCExpr("redis/mset", [mapping]) as any;
     },
     /** Append a value to a key. */
@@ -95,7 +97,10 @@ export function buildRedisApi() {
       return makeCExpr("redis/hget", [key, field]) as any;
     },
     /** Set fields in a hash. */
-    hset(key: string | CExpr<string>, mapping: Liftable<Record<string, string>>): CExpr<number, "redis/hset", [string | CExpr<string>, Liftable<Record<string, string>>]> {
+    hset(
+      key: string | CExpr<string>,
+      mapping: Liftable<Record<string, string>>,
+    ): CExpr<number, "redis/hset", [string | CExpr<string>, Liftable<Record<string, string>>]> {
       return makeCExpr("redis/hset", [key, mapping]) as any;
     },
     /** Get the values of multiple hash fields. */

--- a/packages/plugin-redis/src/5.4.1/build-methods.ts
+++ b/packages/plugin-redis/src/5.4.1/build-methods.ts
@@ -1,4 +1,4 @@
-import type { CExpr } from "@mvfm/core";
+import type { CExpr, Liftable } from "@mvfm/core";
 import { makeCExpr } from "@mvfm/core";
 
 /**
@@ -51,7 +51,7 @@ export function buildRedisApi() {
       return makeCExpr("redis/mget", [...keys]) as any;
     },
     /** Set multiple key-value pairs. */
-    mset<A>(mapping: A): CExpr<"OK", "redis/mset", [A]> {
+    mset(mapping: Liftable<Record<string, string>>): CExpr<"OK", "redis/mset", [Liftable<Record<string, string>>]> {
       return makeCExpr("redis/mset", [mapping]) as any;
     },
     /** Append a value to a key. */
@@ -95,7 +95,7 @@ export function buildRedisApi() {
       return makeCExpr("redis/hget", [key, field]) as any;
     },
     /** Set fields in a hash. */
-    hset<A, B>(key: A, mapping: B): CExpr<number, "redis/hset", [A, B]> {
+    hset(key: string | CExpr<string>, mapping: Liftable<Record<string, string>>): CExpr<number, "redis/hset", [string | CExpr<string>, Liftable<Record<string, string>>]> {
       return makeCExpr("redis/hset", [key, mapping]) as any;
     },
     /** Get the values of multiple hash fields. */


### PR DESCRIPTION
Closes #320

## What this does
Replaces generic type parameters with specific `Liftable<T>` types on cloudflare-kv (`put`, `list`) and redis (`mset`, `hset`) constructors, matching the pattern already used by other migrated plugins (anthropic, s3, stripe, resend, fal).

## Design alignment
- **Type safety**: Users now get autocomplete and error checking for `KvPutOptions`, `KvListOptions`, and `Record<string, string>` parameters instead of unconstrained generics.
- **Consistency**: All Liftable-migrated plugins now use the same specific-type pattern on their constructors.

## Validation performed
- `pnpm --filter @mvfm/plugin-cloudflare-kv exec tsc -p tsconfig.json --noEmit` — clean
- `pnpm --filter @mvfm/plugin-redis exec tsc -p tsconfig.json --noEmit` — clean
- `pnpm --filter @mvfm/plugin-cloudflare-kv run test` — 42 tests passing
- `pnpm --filter @mvfm/plugin-redis run test` — 35 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Cloudflare KV plugin: tightened put() and list() signatures — keys, values and options now require stricter, more specific types.
  * Redis plugin: tightened mset() and hset() signatures — mappings and key parameters now require more explicit typed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->